### PR TITLE
atad: implement readiness checks during init

### DIFF
--- a/modules/iopcore/cdvdman/atad.c
+++ b/modules/iopcore/cdvdman/atad.c
@@ -253,13 +253,11 @@ int atad_start(void)
     bdm_connect_bd(&g_ata_bd);
 #endif
 
-    res = ata_wait_for_busy_clear(30000);
-    if (res < 0)
-        goto out;
+    if (ata_wait_for_busy_clear(30000) < 0)
+        return 1;
 
-    res = ata_wait_for_ready(5000);
-    if (res < 0)
-        goto out;
+    if (ata_wait_for_ready(5000) < 0)
+        return 1;
 
     M_PRINTF("Driver loaded.\n");
     return 0;

--- a/modules/iopcore/cdvdman/atad.c
+++ b/modules/iopcore/cdvdman/atad.c
@@ -134,6 +134,47 @@ static void ata_shutdown_cb(void);
 
 int ata_device_sector_io_internal(int device, void *buf, u64 lba, u32 nsectors, int dir);
 
+/* Wait until the ATA device becomes basically ready for commands.
+   BUSY must be clear (spin-up / firmware init done).
+   DRDY is validated later by ata_wait_for_ready() according to ATA spec.
+*/
+static int ata_wait_for_busy_clear(int timeout)
+{
+    USE_ATA_REGS;
+
+    for (int waited = 0; waited < timeout; waited++) {
+        if (!(ata_hwport->r_status & ATA_STAT_BUSY))
+            return 0;
+
+        DelayThread(1000);
+    }
+
+    M_PRINTF("ata_wait_for_busy_clear TIMEOUT after %d ms\n", timeout);
+    return ATA_RES_ERR_TIMEOUT;
+}
+
+static int ata_wait_for_ready(int timeout)
+{
+    USE_ATA_REGS;
+
+    for (int waited = 0; waited < timeout; waited++) {
+        u8 status = ata_hwport->r_status;
+
+        if (!(status & ATA_STAT_BUSY) && (status & ATA_STAT_READY))
+            return 0;
+
+        if (status & ATA_STAT_ERR) {
+            M_PRINTF("ata_wait_for_ready ERR: status=0x%02x err=0x%02x\n", status, sceAtaGetError());
+            return ATA_RES_ERR_IO;
+        }
+
+        DelayThread(1000);
+    }
+
+    M_PRINTF("ata_wait_for_ready TIMEOUT after %d ms\n", timeout);
+    return ATA_RES_ERR_TIMEOUT;
+}
+
 #ifndef ATA_GAMESTAR_WORKAROUND
 /* In v1.04, DMA was enabled in ata_set_dir() instead. */
 static void ata_pre_dma_cb(int bcr, int dir)
@@ -211,6 +252,15 @@ int atad_start(void)
     // Let bdm device support handle registering the block device.
     bdm_connect_bd(&g_ata_bd);
 #endif
+
+    res = ata_wait_for_busy_clear(30000);
+    if (res < 0)
+        goto out;
+
+    res = ata_wait_for_ready(5000);
+    if (res < 0)
+        goto out;
+
     M_PRINTF("Driver loaded.\n");
     return 0;
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

Improves wOPL’s startup reliability by adding a simple readiness check for HDDs during ATAD initialization. 

By confirming the drive is ready before wOPL begins scanning devices, startup becomes stable across a wide range of HDDs, SSDs, and SATA bridges.

Testing shows predictable boot times and stable behavior.

| Device / Drive | Size | Cold Boot | Warm Boot |
|----------------|------|-----------|-----------|
| Seagate ST310014ACE (PATA) | 10GB | ~10 s | ~5 s |
| WD800BB (PATA, dead) | 80GB | 35 s timeout (without readiness gate ~42 s) | — |
| Seagate Exos X14 (SATA) | 14TB | ~24 s | ~7 s |
| HGST (SATA) | 6TB | ~25 s | ~8 s |

There appears to be about a 4 second delay prior to boot initialization.

Without the readiness gate, boot times are roughly the same.

Some thoughts regarding future improvements:
- It would be cool to store errors and display them within the UI
- Would it be worth aligning with OPL's ATA driver?
