### PR TITLE
Coverflow improvements

### DIFF
--- a/include/menusys.h
+++ b/include/menusys.h
@@ -61,7 +61,7 @@ typedef struct menu_item
     void *userdata;
 
     /// submenu, selection and page start (only used in static mode)
-    struct submenu_list *submenu, *current, *pagestart;
+    struct submenu_list *submenu, *current, *pagestart, *last;
 
     short remindLast;
 

--- a/include/themes.h
+++ b/include/themes.h
@@ -163,7 +163,6 @@ int thmFindGuiID(const char *theme);
 const char **thmGetGuiList(void);
 char *thmGetFilePath(int themeID);
 
-extern int isAnimating;
-extern int animationDirection;
+extern void thmTriggerCoverflowAnim(int direction);
 
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -1008,6 +1008,7 @@ static void guiHandleOp(struct gui_update_t *item)
                     DisableCron = 0; // Release Auto Start Last Played counter
             }
 
+            item->menu.menu->last = result;
             break;
 
         case GUI_OP_SELECT_MENU:
@@ -1020,6 +1021,7 @@ static void guiHandleOp(struct gui_update_t *item)
             item->menu.menu->submenu = NULL;
             item->menu.menu->current = NULL;
             item->menu.menu->pagestart = NULL;
+            item->menu.menu->last = NULL;
             break;
 
         case GUI_OP_SORT:
@@ -1030,6 +1032,11 @@ static void guiHandleOp(struct gui_update_t *item)
                 item->menu.menu->current = item->menu.menu->submenu;
 
             item->menu.menu->pagestart = item->menu.menu->current;
+
+            submenu_list_t *tail = item->menu.menu->submenu;
+            while (tail && tail->next)
+                tail = tail->next;
+            item->menu.menu->last = tail;
             break;
 
         case GUI_OP_ADD_HINT:

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -751,6 +751,7 @@ static void menuNextV()
 
         selected_item->item->pagestart = selected_item->item->current;
     } else { // wrap to start
+        thmTriggerCoverflowAnim(1);
         menuFirstPage();
     }
 }
@@ -772,6 +773,7 @@ static void menuPrevV()
                 selected_item->item->pagestart = selected_item->item->pagestart->prev;
         }
     } else { // wrap to end
+        thmTriggerCoverflowAnim(-1);
         menuLastPage();
     }
 }
@@ -1420,6 +1422,7 @@ void menuClearGameList(opl_io_module_t *mdl)
         mdl->menuItem.submenu = NULL;
         mdl->menuItem.current = NULL;
         mdl->menuItem.pagestart = NULL;
+        mdl->menuItem.last = NULL;
         mdl->menuItem.remindLast = 0;
 
         // unlock

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -738,8 +738,7 @@ static void menuNextV()
         selected_item->item->current = cur->next;
         sfxPlay(SFX_CURSOR);
 
-        isAnimating = 1;
-        animationDirection = 1;
+        thmTriggerCoverflowAnim(1);
 
         // if the current item is beyond the page start, move the page start one page down
         cur = selected_item->item->pagestart;
@@ -764,8 +763,7 @@ static void menuPrevV()
         selected_item->item->current = cur->prev;
         sfxPlay(SFX_CURSOR);
 
-        isAnimating = 1;
-        animationDirection = -1;
+        thmTriggerCoverflowAnim(-1);
 
         // if the current item is on the page start, move the page start one page up
         if (selected_item->item->pagestart == cur) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -1033,15 +1033,28 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     int coverDistance = coverWidth + coverSpacing;
     int basePosX = (coverSpacing << 1) + (coverWidth >> 1);
 
+    // Wrap left, if no prev.. use last item in the submenu list
+    submenu_list_t *leftItem = item->prev;
+    if (leftItem == NULL && menu->item->last != NULL && menu->item->last != item)
+        leftItem = menu->item->last;
+
+    // Wrap right, if no next.. use first item in the submeny list
+    submenu_list_t *rightItem = item->next;
+    if (rightItem == NULL) {
+        rightItem = menu->item->submenu; // head of the submenu list
+        if (rightItem == item)           // only 1 item.. dont show same item twice
+            rightItem = NULL;
+    }
+
     struct
     {
         submenu_list_t *game;
         mutable_image_t *cover;
         GSTEXTURE *texture;
     } covers[COVERFLOW_COUNT] = {
-        {item->prev, NULL, NULL},
+        {leftItem, NULL, NULL},
         {item, NULL, NULL},
-        {item->next, NULL, NULL}};
+        {rightItem, NULL, NULL}};
 
     float eased = 1.0f;
     float animOffset = 0.0f;

--- a/src/themes.c
+++ b/src/themes.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <dirent.h>
+#include <time.h>
 
 #define MENU_POS_V      50
 #define HINT_HEIGHT     32
@@ -996,8 +997,17 @@ static void drawInfoHintText(struct menu_list *menu, struct submenu_list *item, 
 
 // Coverflow ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-int isAnimating = 0;        // Animation flag
-int animationDirection = 0; // 1 for right (next), -1 for left (prev)
+static int isAnimating = 0;        // Animation flag
+static int animationDirection = 0; // 1 for right (next), -1 for left (prev)
+static clock_t animationStartTime = 0;
+#define COVERFLOW_ANIM_DURATION_MS 200
+
+void thmTriggerCoverflowAnim(int direction)
+{
+    isAnimating = 1;
+    animationDirection = direction;
+    animationStartTime = clock();
+}
 
 static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
 {
@@ -1021,10 +1031,7 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         coverSpacing = rmWideScale(coverSpacing);
 
     int coverDistance = coverWidth + coverSpacing;
-    int posX = (coverSpacing << 1) + (coverWidth >> 1);
-
-    float animationProgress = 0.0f; // Progress of animation (0.0 - 1.0)
-    float animationSpeed = 0.05f;   // Speed of animation
+    int basePosX = (coverSpacing << 1) + (coverWidth >> 1);
 
     struct
     {
@@ -1036,16 +1043,30 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         {item, NULL, NULL},
         {item->next, NULL, NULL}};
 
+    float eased = 1.0f;
+    float animOffset = 0.0f;
     if (isAnimating) {
-        posX += animationDirection * (animationProgress * coverDistance);
-        animationProgress += animationSpeed;
-        if (animationProgress >= 1.0f) {
+        clock_t elapsed = clock() - animationStartTime;
+        float t = (float)elapsed / ((float)COVERFLOW_ANIM_DURATION_MS * CLOCKS_PER_SEC / 1000);
+
+        if (t >= 1.0f) {
+            t = 1.0f;
             isAnimating = 0;
-            animationProgress = 0.0f;
+            animationStartTime = 0;
         }
+
+        float inv = 1.0f - t;
+        eased = 1.0f - inv * inv * inv;
+        animOffset = (float)animationDirection * (float)coverDistance * (eased - 1.0f);
     }
 
+    int posX = basePosX + (int)animOffset;
+
     int scaling = 30;
+    // direction=1 (next): covers[2] is visually at center at t=0
+    // direction=-1 (prev): covers[0] is visually at center at t=0
+    int leavingIndex = (animationDirection > 0) ? 2 : 0;
+
     for (int i = 0; i < COVERFLOW_COUNT; i++) {
         int renderPosX = posX;
         posX += coverDistance;
@@ -1058,11 +1079,22 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         int overlayOffsetY = 0;
         int overlayOffsetX = 0;
 
+        // Interpolate scaling.. center cover grows in.. leaving cover shrinks out
+        int currentScaling = 0;
         if (i == 1) {
-            currentCoverWidth += scaling;
-            currentCoverHeight += scaling;
-            overlayOffsetY = scaling;
-            overlayOffsetX = scaling * (gWideScreen ? (4.0f / 3.0f) : 1.0f) - (scaling * ((4.0f / 3.0f) - 1.0f) / 2.0f);
+            // New selection.. grows into center as animation progresses
+            float growFactor = isAnimating ? eased : 1.0f;
+            currentScaling = (int)(scaling * growFactor);
+        } else if (isAnimating && i == leavingIndex) {
+            // Cover leaving center.. shrinks as animation progresses
+            currentScaling = (int)(scaling * (1.0f - eased));
+        }
+
+        if (currentScaling > 0) {
+            currentCoverWidth += currentScaling;
+            currentCoverHeight += currentScaling;
+            overlayOffsetY = currentScaling;
+            overlayOffsetX = currentScaling * (gWideScreen ? (4.0f / 3.0f) : 1.0f) - (currentScaling * ((4.0f / 3.0f) - 1.0f) / 2.0f);
         }
 
         covers[i].cover = (mutable_image_t *)elem->extended;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Only tested on pcsx2 so please feel free to test on real hw.

Coverflow animation is now time based since the draw function is just spammed repeatedly, shifts and scales to make it look a bit nicer. It also wraps now visually not just navigation, so you will see the last game to the left of the first etc.

Could potentially render a cover either side off screen for a smoother feel/look but I didn't bother as it may cause vram usage issues on higher res vmodes.. and I just couldn't be bothered.