### PR TITLE
Maintain aspect ratio of APP_MODE items on FAV_MODE

### DIFF
--- a/include/renderman.h
+++ b/include/renderman.h
@@ -99,15 +99,10 @@ void rmDrawQuad(rm_quad_t *q);
 void rmSetBackground(GSTEXTURE *txt);
 
 /** Queues a specified pixmap (tinted with colour) to be rendered on specified position */
-void rmDrawPixmap(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color);
+void rmDrawPixmap(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color, int reflection);
 
 void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w, int h, short scaled, u64 color,
-                         GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry);
-
-void rmDrawPixmapWithReflection(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color);
-
-void rmDrawOverlayPixmapWithReflection(GSTEXTURE *overlay, int x, int y, short aligned, int w, int h, short scaled, u64 color,
-                                       GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry);
+                         GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry, int reflection);
 
 /** Queues a opaque rectangle to be rendered */
 void rmDrawRect(int x, int y, int w, int h, u64 color);

--- a/src/dia.c
+++ b/src/dia.c
@@ -124,7 +124,7 @@ int diaShowKeyb(char *text, int maxLen, int hide_text, const char *title)
             if (cmdicons[i]) {
                 int w = (cmdicons[i]->Width * 20) / cmdicons[i]->Height;
                 int h = 20;
-                rmDrawPixmap(cmdicons[i], 436, 170 + 3 * UI_SPACING_H * i, ALIGN_NONE, w, h, SCALING_RATIO, gDefaultCol);
+                rmDrawPixmap(cmdicons[i], 436, 170 + 3 * UI_SPACING_H * i, ALIGN_NONE, w, h, SCALING_RATIO, gDefaultCol, 0);
             }
 
             x = 477;

--- a/src/gui.c
+++ b/src/gui.c
@@ -1081,7 +1081,7 @@ static void guiDrawBusy(int alpha)
         GSTEXTURE *texture = thmGetTexture(LOAD1_ICON + (guiFrameId >> 1) % gTheme->loadingIconCount);
         if (texture && texture->Mem) {
             u64 mycolor = GS_SETREG_RGBA(0x80, 0x80, 0x80, alpha);
-            rmDrawPixmap(texture, gTheme->loadingIcon->posX, gTheme->loadingIcon->posY, gTheme->loadingIcon->aligned, gTheme->loadingIcon->width, gTheme->loadingIcon->height, gTheme->loadingIcon->scaled, mycolor);
+            rmDrawPixmap(texture, gTheme->loadingIcon->posX, gTheme->loadingIcon->posY, gTheme->loadingIcon->aligned, gTheme->loadingIcon->width, gTheme->loadingIcon->height, gTheme->loadingIcon->scaled, mycolor, 0);
         }
     }
 }
@@ -1094,7 +1094,7 @@ static void guiRenderGreeting(int alpha)
     GSTEXTURE *logo = thmGetTexture(LOGO_01 + (guiFrameId / 6) % gTheme->logoIconCount);
     if (logo) {
         mycolor = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, alpha);
-        rmDrawPixmap(logo, screenWidth >> 1, gTheme->usedHeight >> 1, ALIGN_CENTER, logo->Width, logo->Height, SCALING_RATIO, mycolor);
+        rmDrawPixmap(logo, screenWidth >> 1, gTheme->usedHeight >> 1, ALIGN_CENTER, logo->Width, logo->Height, SCALING_RATIO, mycolor, 0);
     }
 }
 
@@ -1322,7 +1322,7 @@ int guiDrawIconAndText(int iconId, int textId, int font, int x, int y, u64 color
 
     if (iconTex && iconTex->Mem) {
         y += h >> 1;
-        rmDrawPixmap(iconTex, x, y, ALIGN_VCENTER, w, h, SCALING_RATIO, gDefaultCol);
+        rmDrawPixmap(iconTex, x, y, ALIGN_VCENTER, w, h, SCALING_RATIO, gDefaultCol, 0);
         x += rmWideScale(w) + 2;
     } else {
         // HACK: font is aligned to VCENTER, the default height icon height is 20

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -360,48 +360,7 @@ void rmSetBackground(GSTEXTURE *txt)
     order++;
 }
 
-void rmDrawPixmap(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color)
-{
-    rm_quad_t quad;
-    rmSetupQuad(txt, x, y, aligned, w, h, scaled, color, &quad);
-    rmDrawQuad(&quad);
-}
-
-void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w, int h, short scaled, u64 color,
-                         GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry)
-{
-    rm_quad_t quad;
-    rmSetupQuad(overlay, x, y, aligned, w, h, scaled, color, &quad);
-    ulx = X_SCALE(ulx * iAspectWidth) >> 2;
-    urx = X_SCALE(urx * iAspectWidth) >> 2;
-    blx = X_SCALE(blx * iAspectWidth) >> 2;
-    brx = X_SCALE(brx * iAspectWidth) >> 2;
-    uly = Y_SCALE(uly);
-    ury = Y_SCALE(ury);
-    bly = Y_SCALE(bly);
-    bry = Y_SCALE(bry);
-
-    if ((inlay->PSM == GS_PSM_CT32) || (inlay->Clut && inlay->ClutPSM == GS_PSM_CT32))
-        gsGlobal->PrimAlphaEnable = GS_SETTING_ON;
-    else
-        gsGlobal->PrimAlphaEnable = GS_SETTING_OFF;
-
-    gsKit_TexManager_bind(gsGlobal, inlay);
-    gsKit_prim_quad_texture(gsGlobal, inlay,
-                            quad.ul.x + ulx + fRenderXOff, quad.ul.y + uly + fRenderYOff,
-                            0.0f, 0.0f,
-                            quad.ul.x + urx + fRenderXOff, quad.ul.y + ury + fRenderYOff,
-                            inlay->Width, 0.0f,
-                            quad.ul.x + blx + fRenderXOff, quad.ul.y + bly + fRenderYOff,
-                            0.0f, inlay->Height,
-                            quad.ul.x + brx + fRenderXOff, quad.ul.y + bry + fRenderYOff,
-                            inlay->Width, inlay->Height, order, gDefaultCol);
-    order++;
-
-    rmDrawQuad(&quad);
-}
-
-void rmDrawPixmapWithReflection(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color)
+void rmDrawPixmap(GSTEXTURE *txt, int x, int y, short aligned, int w, int h, short scaled, u64 color, int reflection)
 {
     rm_quad_t quad;
     rmSetupQuad(txt, x, y, aligned, w, h, scaled, color, &quad);
@@ -422,6 +381,9 @@ void rmDrawPixmapWithReflection(GSTEXTURE *txt, int x, int y, short aligned, int
                               quad.br.u, quad.br.v,
                               order, color);
     order++;
+
+    if (!reflection)
+        return;
 
     float rowHeight = 1.0f;
     float totalHeight = quad.br.y - quad.ul.y;
@@ -453,8 +415,8 @@ void rmDrawPixmapWithReflection(GSTEXTURE *txt, int x, int y, short aligned, int
     }
 }
 
-void rmDrawOverlayPixmapWithReflection(GSTEXTURE *overlay, int x, int y, short aligned, int w, int h, short scaled, u64 color,
-                                       GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry)
+void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w, int h, short scaled, u64 color,
+                         GSTEXTURE *inlay, int ulx, int uly, int urx, int ury, int blx, int bly, int brx, int bry, int reflection)
 {
     rm_quad_t quad;
     rmSetupQuad(overlay, x, y, aligned, w, h, scaled, color, &quad);
@@ -483,9 +445,12 @@ void rmDrawOverlayPixmapWithReflection(GSTEXTURE *overlay, int x, int y, short a
                             0.0f, inlay->Height,
                             quad.ul.x + brx + fRenderXOff, quad.ul.y + bry + fRenderYOff,
                             inlay->Width, inlay->Height, order, gDefaultCol);
-
     order++;
+
     rmDrawQuad(&quad);
+
+    if (!reflection)
+        return;
 
     float rowHeight = 1.0f;
     float totalHeight = quad.br.y - quad.ul.y;

--- a/src/themes.c
+++ b/src/themes.c
@@ -511,9 +511,9 @@ static void drawStaticImage(struct menu_list *menu, struct submenu_list *item, c
     if (staticImage->overlayTexture) {
         rmDrawOverlayPixmap(&staticImage->overlayTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
                             &staticImage->defaultTexture->source, staticImage->overlayTexture->upperLeft_x, staticImage->overlayTexture->upperLeft_y, staticImage->overlayTexture->upperRight_x, staticImage->overlayTexture->upperRight_y,
-                            staticImage->overlayTexture->lowerLeft_x, staticImage->overlayTexture->lowerLeft_y, staticImage->overlayTexture->lowerRight_x, staticImage->overlayTexture->lowerRight_y);
+                            staticImage->overlayTexture->lowerLeft_x, staticImage->overlayTexture->lowerLeft_y, staticImage->overlayTexture->lowerRight_x, staticImage->overlayTexture->lowerRight_y, 0);
     } else
-        rmDrawPixmap(&staticImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+        rmDrawPixmap(&staticImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 }
 
 static void initStaticImage(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *elem, const char *name, const char *imageName)
@@ -555,24 +555,15 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
         int x = gWideScreen ? elem->wsX : elem->posX;
 
         if (gameImage->overlayTexture) {
-            if (elem->reflection)
-                rmDrawOverlayPixmapWithReflection(&gameImage->overlayTexture->source, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
-                                                  texture, gameImage->overlayTexture->upperLeft_x, gameImage->overlayTexture->upperLeft_y, gameImage->overlayTexture->upperRight_x, gameImage->overlayTexture->upperRight_y,
-                                                  gameImage->overlayTexture->lowerLeft_x, gameImage->overlayTexture->lowerLeft_y, gameImage->overlayTexture->lowerRight_x, gameImage->overlayTexture->lowerRight_y);
-            else
-                rmDrawOverlayPixmap(&gameImage->overlayTexture->source, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
-                                    texture, gameImage->overlayTexture->upperLeft_x, gameImage->overlayTexture->upperLeft_y, gameImage->overlayTexture->upperRight_x, gameImage->overlayTexture->upperRight_y,
-                                    gameImage->overlayTexture->lowerLeft_x, gameImage->overlayTexture->lowerLeft_y, gameImage->overlayTexture->lowerRight_x, gameImage->overlayTexture->lowerRight_y);
-        } else {
-            if (elem->reflection)
-                rmDrawPixmapWithReflection(texture, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
-            else
-                rmDrawPixmap(texture, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
-        }
+            rmDrawOverlayPixmap(&gameImage->overlayTexture->source, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
+                                texture, gameImage->overlayTexture->upperLeft_x, gameImage->overlayTexture->upperLeft_y, gameImage->overlayTexture->upperRight_x, gameImage->overlayTexture->upperRight_y,
+                                gameImage->overlayTexture->lowerLeft_x, gameImage->overlayTexture->lowerLeft_y, gameImage->overlayTexture->lowerRight_x, gameImage->overlayTexture->lowerRight_y, elem->reflection);
+        } else
+            rmDrawPixmap(texture, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, elem->reflection);
 
     } else if (elem->type == ELEM_TYPE_BACKGROUND) {
         if (gameImage->defaultTexture)
-            rmDrawPixmap(&gameImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+            rmDrawPixmap(&gameImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
         else
             guiDrawBGPlasma();
     }
@@ -616,7 +607,7 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
                 }
                 GSTEXTURE *texture = thmGetTexture(texId);
                 if (texture && texture->Mem)
-                    rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+                    rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 
                 return;
             } else {
@@ -626,9 +617,9 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
                     if (attributeImage->overlayTexture) {
                         rmDrawOverlayPixmap(&attributeImage->overlayTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
                                             texture, attributeImage->overlayTexture->upperLeft_x, attributeImage->overlayTexture->upperLeft_y, attributeImage->overlayTexture->upperRight_x, attributeImage->overlayTexture->upperRight_y,
-                                            attributeImage->overlayTexture->lowerLeft_x, attributeImage->overlayTexture->lowerLeft_y, attributeImage->overlayTexture->lowerRight_x, attributeImage->overlayTexture->lowerRight_y);
+                                            attributeImage->overlayTexture->lowerLeft_x, attributeImage->overlayTexture->lowerLeft_y, attributeImage->overlayTexture->lowerRight_x, attributeImage->overlayTexture->lowerRight_y, 0);
                     } else
-                        rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+                        rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 
                     return;
                 }
@@ -636,7 +627,7 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
         }
     }
     if (attributeImage->defaultTexture)
-        rmDrawPixmap(&attributeImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+        rmDrawPixmap(&attributeImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 }
 
 static void initAttributeImage(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *elem, const char *name)
@@ -796,7 +787,7 @@ static void drawMenuIcon(struct menu_list *menu, struct submenu_list *item, conf
 {
     GSTEXTURE *menuIconTex = thmGetTexture(menu->item->icon_id);
     if (menuIconTex && menuIconTex->Mem)
-        rmDrawPixmap(menuIconTex, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+        rmDrawPixmap(menuIconTex, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 }
 
 static int findMenuNext(struct menu_list *menu)
@@ -838,14 +829,14 @@ static void drawMenuText(struct menu_list *menu, struct submenu_list *item, conf
     if (elem->aligned) {
         int offset = elem->width >> 1;
         if (leftIconTex && leftIconTex->Mem)
-            rmDrawPixmap(leftIconTex, elem->posX - offset, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol);
+            rmDrawPixmap(leftIconTex, elem->posX - offset, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol, 0);
         if (rightIconTex && rightIconTex->Mem)
-            rmDrawPixmap(rightIconTex, elem->posX + offset, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol);
+            rmDrawPixmap(rightIconTex, elem->posX + offset, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol, 0);
     } else {
         if (leftIconTex && leftIconTex->Mem)
-            rmDrawPixmap(leftIconTex, elem->posX - leftIconTex->Width, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol);
+            rmDrawPixmap(leftIconTex, elem->posX - leftIconTex->Width, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol, 0);
         if (rightIconTex && rightIconTex->Mem)
-            rmDrawPixmap(rightIconTex, elem->posX + elem->width, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol);
+            rmDrawPixmap(rightIconTex, elem->posX + elem->width, elem->posY, elem->aligned, 20, 20, elem->scaled, gDefaultCol, 0);
     }
     fntRenderString(elem->font, elem->posX, elem->posY, elem->aligned, 0, 0, menuItemGetText(menu->item), elem->color);
 }
@@ -868,7 +859,7 @@ static void drawBDMIndex(struct menu_list *menu, struct submenu_list *item, conf
 
     GSTEXTURE *indexTex = thmGetTexture(texLookupInternalTexId(&imgName[0]));
     if (indexTex && indexTex->Mem)
-        rmDrawPixmap(indexTex, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol);
+        rmDrawPixmap(indexTex, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
 }
 
 static void drawItemsList(struct menu_list *menu, struct submenu_list *item, config_set_t *config, struct theme_element *elem)
@@ -895,10 +886,10 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
             if (itemsList->decoratorImage) {
                 GSTEXTURE *itemIconTex = getGameImageTexture(itemsList->decoratorImage->cache, menu->item->userdata, &ps->item);
                 if (itemIconTex && itemIconTex->Mem)
-                    rmDrawPixmap(itemIconTex, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol);
+                    rmDrawPixmap(itemIconTex, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol, 0);
                 else {
                     if (itemsList->decoratorImage->defaultTexture)
-                        rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol);
+                        rmDrawPixmap(&itemsList->decoratorImage->defaultTexture->source, posX, posY, elem->aligned, DECORATOR_SIZE, DECORATOR_SIZE, elem->scaled, gDefaultCol, 0);
                 }
                 fntRenderString(elem->font, elem->posX + DECORATOR_SIZE, posY, elem->aligned, elem->width, elem->height, submenuItemGetText(&ps->item), color);
             } else
@@ -919,7 +910,7 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
 
                 GSTEXTURE *favMark = thmGetTexture(FAV_MARK);
                 if (favMark && favMark->Mem)
-                    rmDrawPixmap(favMark, favMarkX + 2, favMarkPosY, ALIGN_NONE, 8, 8, elem->scaled, gDefaultCol);
+                    rmDrawPixmap(favMark, favMarkX + 2, favMarkPosY, ALIGN_NONE, 8, 8, elem->scaled, gDefaultCol, 0);
             }
 
             posY += MENU_ITEM_HEIGHT;
@@ -1116,22 +1107,12 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
             covers[i].texture = (covers[i].cover->defaultTexture) ? &covers[i].cover->defaultTexture->source : thmGetTexture(COVER_DEFAULT);
 
         if (covers[i].cover->overlayTexture) {
-            if (elem->reflection)
-                rmDrawOverlayPixmapWithReflection(&covers[i].cover->overlayTexture->source, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol,
-                                                  covers[i].texture, covers[i].cover->overlayTexture->upperLeft_x, covers[i].cover->overlayTexture->upperLeft_y, covers[i].cover->overlayTexture->upperRight_x + overlayOffsetX,
-                                                  covers[i].cover->overlayTexture->upperRight_y, covers[i].cover->overlayTexture->lowerLeft_x, covers[i].cover->overlayTexture->lowerLeft_y + overlayOffsetY,
-                                                  covers[i].cover->overlayTexture->lowerRight_x + overlayOffsetX, covers[i].cover->overlayTexture->lowerRight_y + overlayOffsetY);
-            else
-                rmDrawOverlayPixmap(&covers[i].cover->overlayTexture->source, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol,
-                                    covers[i].texture, covers[i].cover->overlayTexture->upperLeft_x, covers[i].cover->overlayTexture->upperLeft_y, covers[i].cover->overlayTexture->upperRight_x + overlayOffsetX,
-                                    covers[i].cover->overlayTexture->upperRight_y, covers[i].cover->overlayTexture->lowerLeft_x, covers[i].cover->overlayTexture->lowerLeft_y + overlayOffsetY,
-                                    covers[i].cover->overlayTexture->lowerRight_x + overlayOffsetX, covers[i].cover->overlayTexture->lowerRight_y + overlayOffsetY);
-        } else {
-            if (elem->reflection)
-                rmDrawPixmapWithReflection(covers[i].texture, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol);
-            else
-                rmDrawPixmap(covers[i].texture, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol);
-        }
+            rmDrawOverlayPixmap(&covers[i].cover->overlayTexture->source, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol,
+                                covers[i].texture, covers[i].cover->overlayTexture->upperLeft_x, covers[i].cover->overlayTexture->upperLeft_y, covers[i].cover->overlayTexture->upperRight_x + overlayOffsetX,
+                                covers[i].cover->overlayTexture->upperRight_y, covers[i].cover->overlayTexture->lowerLeft_x, covers[i].cover->overlayTexture->lowerLeft_y + overlayOffsetY,
+                                covers[i].cover->overlayTexture->lowerRight_x + overlayOffsetX, covers[i].cover->overlayTexture->lowerRight_y + overlayOffsetY, elem->reflection);
+        } else
+            rmDrawPixmap(covers[i].texture, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol, elem->reflection);
     }
 }
 

--- a/src/themes.c
+++ b/src/themes.c
@@ -280,6 +280,69 @@ static void initAttributeText(const char *themePath, config_set_t *themeConfig, 
 
 // Common functions for Image ///////////////////////////////////////////////////////////////////////////////////////////////
 
+// Get the actual source item_list for a submenu item
+// On the FAV page.. items redirect to their original source list to maintain aspect ratio
+static item_list_t *thmGetItemSource(struct menu_list *menu, struct submenu_list *item)
+{
+    item_list_t *list = (item_list_t *)menu->item->userdata;
+    if (item && item->item.owner && list->mode == FAV_MODE)
+        return (item_list_t *)item->item.owner;
+    return list;
+}
+
+// Find a theme_element_t in an element list by cache suffix
+static theme_element_t *thmFindElemBySuffix(theme_elems_t *elems, const char *suffix)
+{
+    theme_element_t *elem = elems->first;
+    while (elem) {
+        if (elem->type == ELEM_TYPE_GAME_IMAGE || elem->type == ELEM_TYPE_COVERFLOW) {
+            if (elem->extended) {
+                mutable_image_t *img = (mutable_image_t *)elem->extended;
+                if (img->cache && strcmp(img->cache->suffix, suffix) == 0)
+                    return elem;
+            }
+        }
+        elem = elem->next;
+    }
+    return NULL;
+}
+
+// Get the appropriate theme_element for an item.
+// On the FAV page.. APP_MODE items use the apps element for correct position, dimensions and overlay.
+static theme_element_t *thmGetElemForItem(theme_element_t *defaultElem, struct menu_list *menu, struct submenu_list *item)
+{
+    if (!item || !item->item.owner)
+        return defaultElem;
+
+    item_list_t *menuList = (item_list_t *)menu->item->userdata;
+    item_list_t *sourceList = (item_list_t *)item->item.owner;
+
+    if (menuList->mode == FAV_MODE && sourceList->mode == APP_MODE) {
+        mutable_image_t *img = (mutable_image_t *)defaultElem->extended;
+        if (img && img->cache) {
+            theme_element_t *appsElem = thmFindElemBySuffix(&gTheme->appsMainElems, img->cache->suffix);
+            if (appsElem)
+                return appsElem;
+        }
+    }
+    return defaultElem;
+}
+
+// Draw a texture with optional overlay, reflection, and overlay offsets
+// offsetX/offsetY are for animated scaling (coverflow).. 0 for normal use
+static void thmDrawTexture(GSTEXTURE *texture, mutable_image_t *img, int x, int y, short aligned, int w, int h, short scaled,
+                           u64 color, int reflection, int offsetX, int offsetY)
+{
+    if (img->overlayTexture)
+        rmDrawOverlayPixmap(&img->overlayTexture->source, x, y, aligned, w, h, scaled, color, texture,
+                            img->overlayTexture->upperLeft_x, img->overlayTexture->upperLeft_y,
+                            img->overlayTexture->upperRight_x + offsetX, img->overlayTexture->upperRight_y,
+                            img->overlayTexture->lowerLeft_x, img->overlayTexture->lowerLeft_y + offsetY,
+                            img->overlayTexture->lowerRight_x + offsetX, img->overlayTexture->lowerRight_y + offsetY, reflection);
+    else
+        rmDrawPixmap(texture, x, y, aligned, w, h, scaled, color, reflection);
+}
+
 static void findDuplicate(theme_element_t *first, const char *cachePattern, const char *defaultTexture, const char *overlayTexture, mutable_image_t *target)
 {
     theme_element_t *elem = first;
@@ -508,12 +571,7 @@ static void drawStaticImage(struct menu_list *menu, struct submenu_list *item, c
         return;
 
     mutable_image_t *staticImage = (mutable_image_t *)elem->extended;
-    if (staticImage->overlayTexture) {
-        rmDrawOverlayPixmap(&staticImage->overlayTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
-                            &staticImage->defaultTexture->source, staticImage->overlayTexture->upperLeft_x, staticImage->overlayTexture->upperLeft_y, staticImage->overlayTexture->upperRight_x, staticImage->overlayTexture->upperRight_y,
-                            staticImage->overlayTexture->lowerLeft_x, staticImage->overlayTexture->lowerLeft_y, staticImage->overlayTexture->lowerRight_x, staticImage->overlayTexture->lowerRight_y, 0);
-    } else
-        rmDrawPixmap(&staticImage->defaultTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
+    thmDrawTexture(&staticImage->defaultTexture->source, staticImage, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0, 0, 0);
 }
 
 static void initStaticImage(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *elem, const char *name, const char *imageName)
@@ -541,10 +599,14 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
 {
     mutable_image_t *gameImage = (mutable_image_t *)elem->extended;
     if (item) {
-        GSTEXTURE *texture = getGameImageTexture(gameImage->cache, menu->item->userdata, &item->item);
+        item_list_t *sourceList = thmGetItemSource(menu, item);
+        theme_element_t *drawElem = thmGetElemForItem(elem, menu, item);
+        mutable_image_t *img = (mutable_image_t *)drawElem->extended;
+
+        GSTEXTURE *texture = getGameImageTexture(img->cache, sourceList, &item->item);
         if (!texture || !texture->Mem) {
-            if (gameImage->defaultTexture)
-                texture = &gameImage->defaultTexture->source;
+            if (img->defaultTexture)
+                texture = &img->defaultTexture->source;
             else {
                 if (elem->type == ELEM_TYPE_BACKGROUND)
                     guiDrawBGPlasma();
@@ -552,14 +614,8 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
             }
         }
 
-        int x = gWideScreen ? elem->wsX : elem->posX;
-
-        if (gameImage->overlayTexture) {
-            rmDrawOverlayPixmap(&gameImage->overlayTexture->source, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
-                                texture, gameImage->overlayTexture->upperLeft_x, gameImage->overlayTexture->upperLeft_y, gameImage->overlayTexture->upperRight_x, gameImage->overlayTexture->upperRight_y,
-                                gameImage->overlayTexture->lowerLeft_x, gameImage->overlayTexture->lowerLeft_y, gameImage->overlayTexture->lowerRight_x, gameImage->overlayTexture->lowerRight_y, elem->reflection);
-        } else
-            rmDrawPixmap(texture, x, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, elem->reflection);
+        int x = gWideScreen ? drawElem->wsX : drawElem->posX;
+        thmDrawTexture(texture, img, x, drawElem->posY, drawElem->aligned, drawElem->width, drawElem->height, drawElem->scaled, gDefaultCol, drawElem->reflection, 0, 0);
 
     } else if (elem->type == ELEM_TYPE_BACKGROUND) {
         if (gameImage->defaultTexture)
@@ -614,13 +670,7 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
                 int posZ = 0;
                 GSTEXTURE *texture = cacheGetTexture(attributeImage->cache, menu->item->userdata, &posZ, &attributeImage->currentUid, attributeImage->currentValue);
                 if (texture && texture->Mem) {
-                    if (attributeImage->overlayTexture) {
-                        rmDrawOverlayPixmap(&attributeImage->overlayTexture->source, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol,
-                                            texture, attributeImage->overlayTexture->upperLeft_x, attributeImage->overlayTexture->upperLeft_y, attributeImage->overlayTexture->upperRight_x, attributeImage->overlayTexture->upperRight_y,
-                                            attributeImage->overlayTexture->lowerLeft_x, attributeImage->overlayTexture->lowerLeft_y, attributeImage->overlayTexture->lowerRight_x, attributeImage->overlayTexture->lowerRight_y, 0);
-                    } else
-                        rmDrawPixmap(texture, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0);
-
+                    thmDrawTexture(texture, attributeImage, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0, 0, 0);
                     return;
                 }
             }
@@ -1078,8 +1128,15 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         if (covers[i].game == NULL)
             continue;
 
+        // Get the appropriate element for this item (handles APP_MODE on FAV page)
+        covers[i].cover = (mutable_image_t *)elem->extended;
+        theme_element_t *coverElem = thmGetElemForItem(elem, menu, covers[i].game);
+        mutable_image_t *img = (mutable_image_t *)coverElem->extended;
+        item_list_t *sourceList = thmGetItemSource(menu, covers[i].game);
+
+        int baseCoverHeight = (coverElem != elem && coverElem->height != DIM_UNDEF) ? coverElem->height : coverHeight;
         int currentCoverWidth = coverWidth;
-        int currentCoverHeight = coverHeight;
+        int currentCoverHeight = baseCoverHeight;
         int overlayOffsetY = 0;
         int overlayOffsetX = 0;
 
@@ -1101,18 +1158,11 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
             overlayOffsetX = currentScaling * (gWideScreen ? (4.0f / 3.0f) : 1.0f) - (currentScaling * ((4.0f / 3.0f) - 1.0f) / 2.0f);
         }
 
-        covers[i].cover = (mutable_image_t *)elem->extended;
-        covers[i].texture = getGameImageTexture(covers[i].cover->cache, menu->item->userdata, &covers[i].game->item);
+        covers[i].texture = getGameImageTexture(img->cache, sourceList, &covers[i].game->item);
         if (!covers[i].texture || !covers[i].texture->Mem)
-            covers[i].texture = (covers[i].cover->defaultTexture) ? &covers[i].cover->defaultTexture->source : thmGetTexture(COVER_DEFAULT);
+            covers[i].texture = img->defaultTexture ? &img->defaultTexture->source : thmGetTexture(COVER_DEFAULT);
 
-        if (covers[i].cover->overlayTexture) {
-            rmDrawOverlayPixmap(&covers[i].cover->overlayTexture->source, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol,
-                                covers[i].texture, covers[i].cover->overlayTexture->upperLeft_x, covers[i].cover->overlayTexture->upperLeft_y, covers[i].cover->overlayTexture->upperRight_x + overlayOffsetX,
-                                covers[i].cover->overlayTexture->upperRight_y, covers[i].cover->overlayTexture->lowerLeft_x, covers[i].cover->overlayTexture->lowerLeft_y + overlayOffsetY,
-                                covers[i].cover->overlayTexture->lowerRight_x + overlayOffsetX, covers[i].cover->overlayTexture->lowerRight_y + overlayOffsetY, elem->reflection);
-        } else
-            rmDrawPixmap(covers[i].texture, renderPosX, elem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol, elem->reflection);
+        thmDrawTexture(covers[i].texture, img, renderPosX, coverElem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol, elem->reflection, overlayOffsetX, overlayOffsetY);
     }
 }
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
I have refactored the reflection code to be single functions again instead of dupes and we just use an arg to render reflection (should've done this from the beginning but I was being lazy and didn't want to change all rmDraw() calls). Also added some helper functions to themes so we can keep the aspect ratio of apps page items being rendered on fav page and cleaned up some dupe code.

Fixes #178 

Tested on pcsx2.. seems fine with both list mode and cf mode.

<img width="442" height="301" alt="Screenshot 2026-05-27 091513" src="https://github.com/user-attachments/assets/edecc8c1-df66-4545-b469-c9bc0bdbbe11" />
<img width="455" height="296" alt="Screenshot 2026-05-27 091454" src="https://github.com/user-attachments/assets/f9f71e1d-569d-494c-921a-418cbaa093cd" />
