### PR TITLE
Various Fixes (see notes)

### DIFF
--- a/include/system.h
+++ b/include/system.h
@@ -29,6 +29,10 @@ void sysPowerOff(void);
 int sysInitDECI2(void);
 #endif
 
+#ifdef PADEMU
+void sysInitPadEmu(void);
+#endif
+
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags);
 void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath);
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -113,13 +113,13 @@ static void bdmLoadBlockDeviceModules(void)
 {
     WaitSema(bdmLoadModuleLock);
 
-    if (gEnableUSB && !iUSBModLoaded) {
+    /*if (gEnableUSB && !iUSBModLoaded) {
         // Load USB Block Device drivers
         LOG("[USBMASS_BD]:\n");
         sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
 
         iUSBModLoaded = 1;
-    }
+    }*/
 
     if (gEnableILK && !iLinkModLoaded) {
         // Load iLink Block Device drivers
@@ -161,6 +161,12 @@ void bdmLoadModules(void)
     // Load FATFS (mass:) driver
     LOG("[BDMFS_FATFS]:\n");
     sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
+
+    LOG("[USBD]:\n");
+    sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
+
+    LOG("[USBMASS_BD]:\n");
+    sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
 
     // Load Optional Block Device drivers
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);

--- a/src/config.c
+++ b/src/config.c
@@ -428,6 +428,14 @@ void loadConfig()
     lscret = result;
     lscstatus = 0;
     showCfgPopup = 1;
+
+#ifdef PADEMU
+    // DS34 modules were skipped at boot (config not loaded yet).. Now that CONFIG_GAME is available, init PADEMU if globally enabled for the gui.
+    config_set_t *configGame = configGetByType(CONFIG_GAME);
+    gEnablePadEmu = 0;
+    configGetInt(configGame, CONFIG_ITEM_ENABLEPADEMU, &gEnablePadEmu);
+    sysInitPadEmu();
+#endif
 }
 
 static int trySaveConfigBDM(int types)

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -738,7 +738,7 @@ static void menuNextV()
         selected_item->item->current = cur->next;
         sfxPlay(gTheme->coverflow ? SFX_COVERFLOW : SFX_CURSOR);
 
-        thmTriggerCoverflowAnim(1);
+        thmTriggerCoverflowAnim(-1);
 
         // if the current item is beyond the page start, move the page start one page down
         cur = selected_item->item->pagestart;
@@ -751,7 +751,8 @@ static void menuNextV()
 
         selected_item->item->pagestart = selected_item->item->current;
     } else { // wrap to start
-        thmTriggerCoverflowAnim(1);
+        if (selected_item->item->current->next || selected_item->item->current->prev)
+            thmTriggerCoverflowAnim(-1);
         menuFirstPage();
     }
 }
@@ -764,7 +765,7 @@ static void menuPrevV()
         selected_item->item->current = cur->prev;
         sfxPlay(gTheme->coverflow ? SFX_COVERFLOW : SFX_CURSOR);
 
-        thmTriggerCoverflowAnim(-1);
+        thmTriggerCoverflowAnim(1);
 
         // if the current item is on the page start, move the page start one page up
         if (selected_item->item->pagestart == cur) {
@@ -773,7 +774,8 @@ static void menuPrevV()
                 selected_item->item->pagestart = selected_item->item->pagestart->prev;
         }
     } else { // wrap to end
-        thmTriggerCoverflowAnim(-1);
+        if (selected_item->item->current->next || selected_item->item->current->prev)
+            thmTriggerCoverflowAnim(1);
         menuLastPage();
     }
 }

--- a/src/system.c
+++ b/src/system.c
@@ -204,6 +204,26 @@ void sysShutdownDev9(void)
     }
 }
 
+#ifdef PADEMU
+void sysInitPadEmu(void)
+{
+    if (gEnablePadEmu) {
+        int ds3pads = 1; // only one pad enabled
+
+        ds34usb_deinit();
+        ds34bt_deinit();
+
+        LOG("[DS34_USB]:\n");
+        sysLoadModuleBuffer(&ds34usb_irx, size_ds34usb_irx, 4, (char *)&ds3pads);
+        LOG("[DS34_BT]:\n");
+        sysLoadModuleBuffer(&ds34bt_irx, size_ds34bt_irx, 4, (char *)&ds3pads);
+
+        ds34usb_init();
+        ds34bt_init();
+    }
+}
+#endif
+
 void sysReset()
 {
 #ifdef PADEMU
@@ -288,18 +308,7 @@ void sysReset()
     sysLoadModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL);
 
 #ifdef PADEMU
-    int ds3pads = 1; // only one pad enabled
-
-    ds34usb_deinit();
-    ds34bt_deinit();
-
-    LOG("[DS34_USB]:\n");
-    sysLoadModuleBuffer(&ds34usb_irx, size_ds34usb_irx, 4, (char *)&ds3pads);
-    LOG("[DS34_BT]:\n");
-    sysLoadModuleBuffer(&ds34bt_irx, size_ds34bt_irx, 4, (char *)&ds3pads);
-
-    ds34usb_init();
-    ds34bt_init();
+    sysInitPadEmu();
 #endif
 
     fileXioInit();

--- a/src/system.c
+++ b/src/system.c
@@ -1172,7 +1172,7 @@ static const char *getDeviceName(const char *driver)
         return "ata";
     else if (!strncmp(driver, "apa", 3))
         return "apa";
-    else if (!strncmp(driver, "mmce", 3))
+    else if (!strncmp(driver, "mmce", 4))
         return "mmce";
     else
         return "unsupported";

--- a/src/system.c
+++ b/src/system.c
@@ -293,8 +293,7 @@ void sysReset()
     LOG("[POWEROFF]:\n");
     sysLoadModuleBuffer(&poweroff_irx, size_poweroff_irx, 0, NULL);
 
-    LOG("[USBD]:\n");
-    sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
+    bdmLoadModules();
 
     LOG("[ISOFS]:\n");
     sysLoadModuleBuffer(&isofs_irx, size_isofs_irx, 0, NULL);

--- a/src/themes.c
+++ b/src/themes.c
@@ -1039,7 +1039,7 @@ static void drawInfoHintText(struct menu_list *menu, struct submenu_list *item, 
 // Coverflow ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static int isAnimating = 0;        // Animation flag
-static int animationDirection = 0; // 1 for right (next), -1 for left (prev)
+static int animationDirection = 0; // -1 for right (next), 1 for left (prev)
 static clock_t animationStartTime = 0;
 #define COVERFLOW_ANIM_DURATION_MS 200
 
@@ -1117,8 +1117,8 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     int posX = basePosX + (int)animOffset;
 
     int scaling = 30;
-    // direction=1 (next): covers[2] is visually at center at t=0
-    // direction=-1 (prev): covers[0] is visually at center at t=0
+    // direction=-1 (next): covers[2] is visually at center at t=0
+    // direction=1 (prev): covers[0] is visually at center at t=0
     int leavingIndex = (animationDirection > 0) ? 2 : 0;
 
     for (int i = 0; i < COVERFLOW_COUNT; i++) {

--- a/src/themes.c
+++ b/src/themes.c
@@ -923,7 +923,7 @@ static void drawItemsList(struct menu_list *menu, struct submenu_list *item, con
             posY -= elem->height >> 1;
         }
 
-        submenu_list_t *ps = menu->item->pagestart;
+        submenu_list_t *ps = (gTheme->coverflow != NULL) ? item : menu->item->pagestart;
         int others = 0;
         u64 color;
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Coverflow:
Fixed the animation direction (I reversed it accidentally), also only animate if there is more than 1 item on the list.
Edit: Fixed showing correct item title at theme change before navigation.

Animated logo:
Edit: Is borked, revert for now and attempt apng logo at a later date. No use keeping something causing so many issues.

Pademu:
Because pademu auto detects we need to guard it with the enabled variable but force a read after config loaded so it will auto detect for gui still. Should fix #122 

BDM:
This is tricky and currently doesn't work anyway. BDM needs at least one BD driver to be enabled, modules once loaded cannot be unloaded. Currently the "off" switch is visual only and does not stop the module loading since cfg isn't read until later in the boot up cycle and it's defaulted to on. This becomes even more annoying and difficult by the fact if you have cfg on usb with usb on, you can't read the cfg unless its on to begin with. For now just load the modules in the correct order and later on we can look at guarding it properly and having the off switch work as intended and perhaps a small cfg file only for what devices are enabled can be placed on cwd or failing that mc or first found device but that's for a cfg update patch.

I have started migrating cfg to libconfig (only did base and network so far) and it seemed to work quite well.. Step 1 is migrate everything as is, then we can look at splitting up cfg entries and load locations etc.