### PR TITLE
Calculate game size at boot

### DIFF
--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -45,6 +45,7 @@ extern int size_icon_del_icn;
 struct game_list_t
 {
     base_game_info_t gameinfo;
+    char filename[128];
     struct game_list_t *next;
 };
 
@@ -729,6 +730,41 @@ static int queryISOGameListCache(const struct game_cache_list *cache, base_game_
     return ENOENT;
 }
 
+static void applyISOSizes(char *path, struct game_list_t *glist)
+{
+    iox_dirent_t dirent;
+
+    int fd = fileXioDopen(path);
+    if (fd < 0)
+        return;
+
+    while (fileXioDread(fd, &dirent) > 0) {
+        if (dirent.name[0] == '\0')
+            continue;
+
+        u32 sizeMB = (((u64)dirent.stat.hisize << 32) | dirent.stat.size) >> 20;
+        struct game_list_t *g = glist;
+        while (g) {
+            if (g->gameinfo.format == GAME_FORMAT_USBLD) {
+                const char *fname = dirent.name + 12;
+
+                if (!strncmp(fname, g->gameinfo.startup, strlen(g->gameinfo.startup))) {
+                    g->gameinfo.sizeMB += sizeMB;
+                    break;
+                }
+            } else {
+                if (strcmp(g->filename, dirent.name) == 0) {
+                    g->gameinfo.sizeMB = sizeMB;
+                    break;
+                }
+            }
+            g = g->next;
+        }
+    }
+
+    fileXioDclose(fd);
+}
+
 static int scanForISO(char *path, char type, struct game_list_t **glist)
 {
     int count = 0;
@@ -761,6 +797,7 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
             next->next = *glist;
             *glist = next;
             base_game_info_t *game = &next->gameinfo;
+            strcpy(next->filename, dirent->d_name);
             memset(game, 0, sizeof(base_game_info_t));
 
             if (format == GAME_FORMAT_OLD_ISO) {
@@ -811,6 +848,8 @@ static int scanForISO(char *path, char type, struct game_list_t **glist)
     } else {
         updateISOGameList(path, NULL, *glist, count);
     }
+
+    applyISOSizes(path, *glist);
 
     return count;
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

#### Calculate game size at boot
- Allows for the use of `usb_frames_delay=0` with the new coverflow and tar loader (smooth transitions)
- Saves runtime cost calculating size on every game selection
- Minimal overhead for large game lists (runs in under 1 second)
- Does not modify cache