### PR TITLE
Coverflow Improvements 2

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -122,6 +122,11 @@ enum CONFIG_INDEX {
 #define CONFIG_OPL_ENABLE_BDMHDD        "enable_bdm_hdd"
 #define CONFIG_OPL_ENABLE_MMCE          "enable_mmce"
 
+#define CONFIG_OPL_COVERFLOW_COUNT "coverflow_count"
+#define CONFIG_OPL_COVERFLOW_SCALE "coverflow_scale"
+#define CONFIG_OPL_COVERFLOW_ANIM  "coverflow_anim"
+#define CONFIG_OPL_COVERFLOW_DIM   "coverflow_dim"
+
 #define CONFIG_OPL_SWAP_SEL_BUTTON   "swap_select_btn"
 #define CONFIG_OPL_PARENTAL_LOCK_PWD "parental_lock_password"
 #define CONFIG_OPL_SFX               "enable_sfx"

--- a/include/dialogs.h
+++ b/include/dialogs.h
@@ -26,6 +26,7 @@ enum UI_ITEMS {
     UICFG_YOFF,
     UICFG_OVERSCAN,
     UICFG_NOTIFICATIONS,
+    UICFG_COVERFLOW_BUTTON,
 
     CFG_DEBUG,
     CFG_BDM_DEBUG,
@@ -210,6 +211,13 @@ enum UI_ITEMS {
 #endif
 };
 
+enum COVERFLOW_CFG_IDs {
+    CFG_COVERFLOW_COUNT = 1,
+    CFG_COVERFLOW_SCALE,
+    CFG_COVERFLOW_ANIM,
+    CFG_COVERFLOW_DIM,
+};
+
 #define COMPAT_NOEXIT       0x70000000
 #define COMPAT_LOADFROMDISC (COMPAT_LOADFROMDISC_ID | COMPAT_NOEXIT)
 
@@ -247,5 +255,7 @@ extern struct UIItem diaBlockDevicesConfig[];
 
 extern struct UIItem diaOSDConfig[];
 extern struct UIItem diaMMCEConfig[];
+
+extern struct UIItem diaCoverflowConfig[];
 
 #endif

--- a/include/gui.h
+++ b/include/gui.h
@@ -151,6 +151,7 @@ void guiShowAudioConfig();
 void guiShowControllerConfig();
 void guiShowNetConfig();
 void guiShowParentalLockConfig();
+void guiShowCoverflowConfig(void);
 
 void guiCheckNotifications(int checkTheme, int checkLang);
 

--- a/include/themes.h
+++ b/include/themes.h
@@ -134,10 +134,6 @@ typedef struct theme
     theme_element_t *loadingIcon;
     int loadingIconCount;
 
-    // Logo
-    theme_element_t *logoIcon;
-    int logoIconCount;
-
     GSTEXTURE textures[TEXTURES_COUNT];
     int fonts[THM_MAX_FONTS]; //!< Storage of font handles for removal once not needed
 

--- a/include/themes.h
+++ b/include/themes.h
@@ -142,11 +142,17 @@ typedef struct theme
     int fonts[THM_MAX_FONTS]; //!< Storage of font handles for removal once not needed
 
     theme_element_t *coverflow;
+    int coverflowCoverOffset; // used to compensate for asymmetric overlay transparency, in texture pixels (half the transparent padding). e.g. overlay 256px wide with 29px right padding = 14 (29/2)
 } theme_t;
 
 extern theme_t *gTheme;
 
 extern int gDiscEnableArt;
+
+extern int gCoverflowCount;
+extern int gCoverflowCenterScale;
+extern int gCoverflowAnimSpeed;
+extern int gCoverflowDimCovers;
 
 void thmInit(void);
 void thmReinit(const char *path);

--- a/misc/theme_coverflow.cfg
+++ b/misc/theme_coverflow.cfg
@@ -1,6 +1,7 @@
 font1=builtin
 font1_size=20
 plasma_blend_color=#FFFFFF
+coverflow_cover_offset=14
 main0:
 	type=Background
 	default=settings_bg
@@ -33,13 +34,13 @@ main3:
 	height=255
 	overlay=case
 	overlay_ulx=0
-	overlay_uly=12
-	overlay_urx=175
-	overlay_ury=12
+	overlay_uly=13
+	overlay_urx=176
+	overlay_ury=13
 	overlay_llx=0
-	overlay_lly=253
-	overlay_lrx=175
-	overlay_lry=253
+	overlay_lly=254
+	overlay_lrx=176
+	overlay_lry=254
 appsMain3:
 	type=Coverflow
 	default=cover
@@ -49,13 +50,13 @@ appsMain3:
 	height=190
 	overlay=apps_case
 	overlay_ulx=0
-	overlay_uly=8
-	overlay_urx=174
-	overlay_ury=8
+	overlay_uly=9
+	overlay_urx=175
+	overlay_ury=9
 	overlay_llx=0
-	overlay_lly=189
-	overlay_lrx=174
-	overlay_lry=189
+	overlay_lly=190
+	overlay_lrx=175
+	overlay_lry=190
 main4:
 	type=MenuIcon
 	width=180

--- a/src/config.c
+++ b/src/config.c
@@ -384,6 +384,14 @@ void loadConfig()
             configGetInt(configOPL, CONFIG_OPL_BOOT_SND_VOLUME, &gBootSndVolume);
             configGetInt(configOPL, CONFIG_OPL_BGM_VOLUME, &gBGMVolume);
             configGetStrCopy(configOPL, CONFIG_OPL_DEFAULT_BGM_PATH, gDefaultBGMPath, sizeof(gDefaultBGMPath));
+
+            configGetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, &gCoverflowCount);
+            if (gCoverflowCount != 3 && gCoverflowCount != 5)
+                gCoverflowCount = 3;
+
+            configGetInt(configOPL, CONFIG_OPL_COVERFLOW_SCALE, &gCoverflowCenterScale);
+            configGetInt(configOPL, CONFIG_OPL_COVERFLOW_ANIM, &gCoverflowAnimSpeed);
+            configGetInt(configOPL, CONFIG_OPL_COVERFLOW_DIM, &gCoverflowDimCovers);
         }
     }
 
@@ -579,6 +587,11 @@ static void saveConfig()
         configSetInt(configOPL, CONFIG_OPL_YSENSITIVITY, gYSensitivity);
 
         configSetInt(configOPL, CONFIG_OPL_SWAP_SEL_BUTTON, gSelectButton == KEY_CIRCLE ? 0 : 1);
+
+        configSetInt(configOPL, CONFIG_OPL_COVERFLOW_COUNT, gCoverflowCount);
+        configSetInt(configOPL, CONFIG_OPL_COVERFLOW_SCALE, gCoverflowCenterScale);
+        configSetInt(configOPL, CONFIG_OPL_COVERFLOW_ANIM, gCoverflowAnimSpeed);
+        configSetInt(configOPL, CONFIG_OPL_COVERFLOW_DIM, gCoverflowDimCovers);
     }
 
     if (lscstatus & CONFIG_NETWORK) {

--- a/src/dialogs.c
+++ b/src/dialogs.c
@@ -342,6 +342,8 @@ struct UIItem diaUIConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_THEME}}},
     {UI_SPACER},
     {UI_ENUM, UICFG_THEME, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_SPACER},
+    {UI_BUTTON, UICFG_COVERFLOW_BUTTON, 1, 1, -1, 0, 0, {.label = {"Coverflow Settings", -1}}},
     {UI_BREAK},
 
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_LANGUAGE}}},
@@ -413,6 +415,38 @@ struct UIItem diaUIConfig[] = {
     {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {NULL, _STR_WIDE_SCREEN}}},
     {UI_SPACER},
     {UI_BOOL, UICFG_WIDESCREEN, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    // buttons
+    {UI_OK, 0, 1, 1, -1, 0, 0, {.label = {NULL, _STR_OK}}},
+    {UI_BREAK},
+
+    // end of dialog
+    {UI_TERMINATOR}};
+
+// Coverflow Settings Menu
+struct UIItem diaCoverflowConfig[] = {
+    {UI_HEADER, 0, 1, 1, -1, 0, 0, {.label = {"Coverflow Settings", -1}}},
+    {UI_SPLITTER},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Cover Count", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_COVERFLOW_COUNT, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Center Scale", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_COVERFLOW_SCALE, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Animation Speed", -1}}},
+    {UI_SPACER},
+    {UI_ENUM, CFG_COVERFLOW_ANIM, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
+    {UI_BREAK},
+
+    {UI_LABEL, 0, 1, 1, -1, -40, 0, {.label = {"Dim Side Covers", -1}}},
+    {UI_SPACER},
+    {UI_BOOL, CFG_COVERFLOW_DIM, 1, 1, -1, 0, 0, {.intvalue = {0, 0}}},
     {UI_BREAK},
 
     // buttons

--- a/src/gui.c
+++ b/src/gui.c
@@ -669,6 +669,7 @@ reselect_video_mode:
     diaSetInt(diaUIConfig, UICFG_XOFF, gXOff);
     diaSetInt(diaUIConfig, UICFG_YOFF, gYOff);
     diaSetInt(diaUIConfig, UICFG_OVERSCAN, gOverscan);
+    diaSetVisible(diaUIConfig, UICFG_COVERFLOW_BUTTON, gTheme->coverflow != NULL);
     guiUIUpdater(1);
 
     int ret = diaExecuteDialog(diaUIConfig, -1, 1, guiUIUpdater);
@@ -690,6 +691,9 @@ reselect_video_mode:
         diaGetInt(diaUIConfig, UICFG_XOFF, &gXOff);
         diaGetInt(diaUIConfig, UICFG_YOFF, &gYOff);
         diaGetInt(diaUIConfig, UICFG_OVERSCAN, &gOverscan);
+
+        if (ret == UICFG_COVERFLOW_BUTTON)
+            guiShowCoverflowConfig();
 
         if (ret == UICFG_RESETCOL)
             setDefaultColors();
@@ -934,6 +938,53 @@ void guiShowControllerConfig(void)
         }
 #endif
         configApply(-1, -1, 1);
+    }
+}
+
+void guiShowCoverflowConfig(void)
+{
+    int ret;
+
+    const char *coverCounts[] = {"3", "5", NULL};
+    const char *scaleNames[] = {"None", "Small", "Medium", "Large", NULL};
+    const char *animNames[] = {"Off", "Fast", "Normal", "Slow", NULL};
+
+    int scaleValues[] = {0, 15, 30, 45};
+    int animValues[] = {0, 100, 200, 400};
+
+    diaSetEnum(diaCoverflowConfig, CFG_COVERFLOW_COUNT, coverCounts);
+    diaSetEnum(diaCoverflowConfig, CFG_COVERFLOW_SCALE, scaleNames);
+    diaSetEnum(diaCoverflowConfig, CFG_COVERFLOW_ANIM, animNames);
+
+    diaSetInt(diaCoverflowConfig, CFG_COVERFLOW_COUNT, (gCoverflowCount == 5) ? 1 : 0);
+
+    int i, scaleId = 2; // default medium
+    for (i = 0; i < 4; i++)
+        if (scaleValues[i] == gCoverflowCenterScale)
+            scaleId = i;
+    diaSetInt(diaCoverflowConfig, CFG_COVERFLOW_SCALE, scaleId);
+
+    int animId = 2; // default normal
+    for (i = 0; i < 4; i++)
+        if (animValues[i] == gCoverflowAnimSpeed)
+            animId = i;
+    diaSetInt(diaCoverflowConfig, CFG_COVERFLOW_ANIM, animId);
+
+    diaSetInt(diaCoverflowConfig, CFG_COVERFLOW_DIM, gCoverflowDimCovers);
+
+    ret = diaExecuteDialog(diaCoverflowConfig, -1, 1, NULL);
+    if (ret) {
+        int id;
+        diaGetInt(diaCoverflowConfig, CFG_COVERFLOW_COUNT, &id);
+        gCoverflowCount = (id == 1) ? 5 : 3;
+
+        diaGetInt(diaCoverflowConfig, CFG_COVERFLOW_SCALE, &id);
+        gCoverflowCenterScale = scaleValues[id];
+
+        diaGetInt(diaCoverflowConfig, CFG_COVERFLOW_ANIM, &id);
+        gCoverflowAnimSpeed = animValues[id];
+
+        diaGetInt(diaCoverflowConfig, CFG_COVERFLOW_DIM, &gCoverflowDimCovers);
     }
 }
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -1142,7 +1142,7 @@ static void guiRenderGreeting(int alpha)
     u64 mycolor = GS_SETREG_RGBA(0x00, 0x00, 0x00, alpha);
     rmDrawRect(0, 0, screenWidth, screenHeight, mycolor);
 
-    GSTEXTURE *logo = thmGetTexture(LOGO_01 + (guiFrameId / 6) % gTheme->logoIconCount);
+    GSTEXTURE *logo = thmGetTexture(LOGO_01 + (guiFrameId / 6) % (LOGO_21 - LOGO_01 + 1));
     if (logo) {
         mycolor = GS_SETREG_RGBA(0xFF, 0xFF, 0xFF, alpha);
         rmDrawPixmap(logo, screenWidth >> 1, gTheme->usedHeight >> 1, ALIGN_CENTER, logo->Width, logo->Height, SCALING_RATIO, mycolor, 0);

--- a/src/initializer.c
+++ b/src/initializer.c
@@ -215,6 +215,11 @@ static void setDefaults(void)
     gYOff = 0;
     gOverscan = 0;
 
+    gCoverflowCount = 3;
+    gCoverflowCenterScale = 30;
+    gCoverflowAnimSpeed = 200;
+    gCoverflowDimCovers = 0;
+
     setDefaultColors();
 
     // Last Played Auto Start

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -751,7 +751,8 @@ static void menuNextV()
 
         selected_item->item->pagestart = selected_item->item->current;
     } else { // wrap to start
-        thmTriggerCoverflowAnim(-1);
+        if (cur && (cur->next || cur->prev))
+            thmTriggerCoverflowAnim(-1);
         menuFirstPage();
     }
 }
@@ -773,7 +774,8 @@ static void menuPrevV()
                 selected_item->item->pagestart = selected_item->item->pagestart->prev;
         }
     } else { // wrap to end
-        thmTriggerCoverflowAnim(1);
+        if (cur && (cur->next || cur->prev))
+            thmTriggerCoverflowAnim(1);
         menuLastPage();
     }
 }

--- a/src/renderman.c
+++ b/src/renderman.c
@@ -444,7 +444,7 @@ void rmDrawOverlayPixmap(GSTEXTURE *overlay, int x, int y, short aligned, int w,
                             quad.ul.x + blx + fRenderXOff, quad.ul.y + bly + fRenderYOff,
                             0.0f, inlay->Height,
                             quad.ul.x + brx + fRenderXOff, quad.ul.y + bry + fRenderYOff,
-                            inlay->Width, inlay->Height, order, gDefaultCol);
+                            inlay->Width, inlay->Height, order, color);
     order++;
 
     rmDrawQuad(&quad);

--- a/src/themes.c
+++ b/src/themes.c
@@ -1577,8 +1577,6 @@ static void thmLoad(const char *themePath, int themeID)
     newT->favsItemsList = NULL;
     newT->loadingIcon = NULL;
     newT->loadingIconCount = LOAD7_ICON - LOAD1_ICON + 1;
-    newT->logoIcon = NULL;
-    newT->logoIconCount = LOGO_21 - LOGO_01 + 1;
     newT->coverflow = NULL;
     newT->coverflowCoverOffset = 0;
 
@@ -1694,10 +1692,8 @@ static void thmLoad(const char *themePath, int themeID)
     int customBusy = 0;
 
     // LOGO, loaded here to avoid flickering during startup with device in AUTO + theme set
-    for (i = LOGO_01; i <= LOGO_21; i++) {
-        thmLoadResource(&newT->textures[i], i, themePath_temp, GS_PSM_CT32, newT->useDefault);
-    }
-    newT->logoIconCount = i - LOGO_01;
+    for (i = LOGO_01; i <= LOGO_21; i++)
+        texLoadInternal(&newT->textures[i], i);
 
     for (i = LOAD0_ICON; i <= LOAD7_ICON; i++) {
         if (thmLoadResource(&newT->textures[i], i, themePath_temp, GS_PSM_CT32, newT->useDefault) >= 0)

--- a/src/themes.c
+++ b/src/themes.c
@@ -18,10 +18,9 @@
 #include <dirent.h>
 #include <time.h>
 
-#define MENU_POS_V      50
-#define HINT_HEIGHT     32
-#define DECORATOR_SIZE  20
-#define COVERFLOW_COUNT 3
+#define MENU_POS_V     50
+#define HINT_HEIGHT    32
+#define DECORATOR_SIZE 20
 
 extern const char theme_list_cfg;
 extern u16 size_theme_list_cfg;
@@ -330,15 +329,19 @@ static theme_element_t *thmGetElemForItem(theme_element_t *defaultElem, struct m
 
 // Draw a texture with optional overlay, reflection, and overlay offsets
 // offsetX/offsetY are for animated scaling (coverflow).. 0 for normal use
-static void thmDrawTexture(GSTEXTURE *texture, mutable_image_t *img, int x, int y, short aligned, int w, int h, short scaled,
-                           u64 color, int reflection, int offsetX, int offsetY)
+// scaleFactor is for overlay/inlay scaling (coverflow).. 1.0f for normal use
+static void thmDrawTexture(GSTEXTURE *texture, mutable_image_t *img, int x, int y, short aligned, int w, int h, short scaled, u64 color, int reflection, int offsetX, int offsetY, float scaleFactor)
 {
     if (img->overlayTexture)
         rmDrawOverlayPixmap(&img->overlayTexture->source, x, y, aligned, w, h, scaled, color, texture,
-                            img->overlayTexture->upperLeft_x, img->overlayTexture->upperLeft_y,
-                            img->overlayTexture->upperRight_x + offsetX, img->overlayTexture->upperRight_y,
-                            img->overlayTexture->lowerLeft_x, img->overlayTexture->lowerLeft_y + offsetY,
-                            img->overlayTexture->lowerRight_x + offsetX, img->overlayTexture->lowerRight_y + offsetY, reflection);
+                            (int)(img->overlayTexture->upperLeft_x * scaleFactor),
+                            (int)(img->overlayTexture->upperLeft_y * scaleFactor),
+                            (int)(img->overlayTexture->upperRight_x * scaleFactor) + offsetX,
+                            (int)(img->overlayTexture->upperRight_y * scaleFactor),
+                            (int)(img->overlayTexture->lowerLeft_x * scaleFactor),
+                            (int)(img->overlayTexture->lowerLeft_y * scaleFactor) + offsetY,
+                            (int)(img->overlayTexture->lowerRight_x * scaleFactor) + offsetX,
+                            (int)(img->overlayTexture->lowerRight_y * scaleFactor) + offsetY, reflection);
     else
         rmDrawPixmap(texture, x, y, aligned, w, h, scaled, color, reflection);
 }
@@ -571,7 +574,7 @@ static void drawStaticImage(struct menu_list *menu, struct submenu_list *item, c
         return;
 
     mutable_image_t *staticImage = (mutable_image_t *)elem->extended;
-    thmDrawTexture(&staticImage->defaultTexture->source, staticImage, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0, 0, 0);
+    thmDrawTexture(&staticImage->defaultTexture->source, staticImage, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0, 0, 0, 1.0f);
 }
 
 static void initStaticImage(const char *themePath, config_set_t *themeConfig, theme_t *theme, theme_element_t *elem, const char *name, const char *imageName)
@@ -615,7 +618,7 @@ static void drawGameImage(struct menu_list *menu, struct submenu_list *item, con
         }
 
         int x = gWideScreen ? drawElem->wsX : drawElem->posX;
-        thmDrawTexture(texture, img, x, drawElem->posY, drawElem->aligned, drawElem->width, drawElem->height, drawElem->scaled, gDefaultCol, drawElem->reflection, 0, 0);
+        thmDrawTexture(texture, img, x, drawElem->posY, drawElem->aligned, drawElem->width, drawElem->height, drawElem->scaled, gDefaultCol, drawElem->reflection, 0, 0, 1.0f);
 
     } else if (elem->type == ELEM_TYPE_BACKGROUND) {
         if (gameImage->defaultTexture)
@@ -670,7 +673,7 @@ static void drawAttributeImage(struct menu_list *menu, struct submenu_list *item
                 int posZ = 0;
                 GSTEXTURE *texture = cacheGetTexture(attributeImage->cache, menu->item->userdata, &posZ, &attributeImage->currentUid, attributeImage->currentValue);
                 if (texture && texture->Mem) {
-                    thmDrawTexture(texture, attributeImage, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0, 0, 0);
+                    thmDrawTexture(texture, attributeImage, elem->posX, elem->posY, elem->aligned, elem->width, elem->height, elem->scaled, gDefaultCol, 0, 0, 0, 1.0f);
                     return;
                 }
             }
@@ -1041,7 +1044,11 @@ static void drawInfoHintText(struct menu_list *menu, struct submenu_list *item, 
 static int isAnimating = 0;        // Animation flag
 static int animationDirection = 0; // -1 for right (next), 1 for left (prev)
 static clock_t animationStartTime = 0;
-#define COVERFLOW_ANIM_DURATION_MS 200
+
+int gCoverflowCount = 3;
+int gCoverflowCenterScale = 30;
+int gCoverflowAnimSpeed = 200;
+int gCoverflowDimCovers = 0;
 
 void thmTriggerCoverflowAnim(int direction)
 {
@@ -1055,73 +1062,109 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
     if (item == NULL)
         return;
 
+    int coverCount = gCoverflowCount;
+    int centerIndex = coverCount / 2;
+
     int coverSpacing = 0;
     int coverHeight = elem->height;
     int coverWidth = gWideScreen ? rmWideScale(elem->width) : elem->width;
-    int totalCoversWidth = COVERFLOW_COUNT * coverWidth;
+    int origCoverWidth = coverWidth;
+
+    int coverYOffset = 0;
+    int maxCoverWidth = (screenWidth - (coverCount - 1) * 10) / coverCount;
+    if (coverWidth > maxCoverWidth) {
+        int origHeight = coverHeight;
+        coverHeight = (coverHeight * maxCoverWidth) / coverWidth;
+        coverWidth = maxCoverWidth;
+        coverYOffset = (origHeight - coverHeight) / 2;
+    }
+
+    float coverScaleRatio = (origCoverWidth > 0) ? (float)coverWidth / (float)origCoverWidth : 1.0f;
+
+    int totalCoversWidth = coverCount * coverWidth;
     int totalRemainingSpace = screenWidth - totalCoversWidth;
 
-    if (totalRemainingSpace >= 0) {
-        coverSpacing = totalRemainingSpace / 4; // Divide by 4 to distribute the space equally (2 spaces between covers + 2 on the sides)
-        // If coverSpacing ends up negative set it to a minimum value
-        if (coverSpacing < 0)
-            coverSpacing = 0;
-    }
+    coverSpacing = totalRemainingSpace / (coverCount + 1); // Divide by covercount to distribute the space equally (4 spaces for 3 covers.. 6 spaces for 5)
+    // If coverSpacing ends up negative set it to a minimum value
+    if (coverSpacing < 0)
+        coverSpacing = 0;
 
     if (gWideScreen)
         coverSpacing = rmWideScale(coverSpacing);
 
     int coverDistance = coverWidth + coverSpacing;
-    int basePosX = (coverSpacing << 1) + (coverWidth >> 1);
-
-    // Wrap left, if no prev.. use last item in the submenu list
-    submenu_list_t *leftItem = item->prev;
-    if (leftItem == NULL && menu->item->last != NULL && menu->item->last != item)
-        leftItem = menu->item->last;
-
-    // Wrap right, if no next.. use first item in the submeny list
-    submenu_list_t *rightItem = item->next;
-    if (rightItem == NULL) {
-        rightItem = menu->item->submenu; // head of the submenu list
-        if (rightItem == item)           // only 1 item.. dont show same item twice
-            rightItem = NULL;
-    }
+    int totalGroupWidth = (coverCount - 1) * coverDistance + coverWidth;
+    int basePosX = (screenWidth - totalGroupWidth) / 2 + (coverWidth >> 1) + (coverWidth * gTheme->coverflowCoverOffset / 256);
 
     struct
     {
         submenu_list_t *game;
         mutable_image_t *cover;
         GSTEXTURE *texture;
-    } covers[COVERFLOW_COUNT] = {
-        {leftItem, NULL, NULL},
-        {item, NULL, NULL},
-        {rightItem, NULL, NULL}};
+    } covers[5];
+
+    int ci;
+    for (ci = 0; ci < coverCount; ci++) {
+        covers[ci].game = NULL;
+        covers[ci].cover = NULL;
+        covers[ci].texture = NULL;
+    }
+
+    covers[centerIndex].game = item;
+
+    // Populate left, walk backwards from center
+    submenu_list_t *cur = item;
+    for (ci = centerIndex - 1; ci >= 0; ci--) {
+        submenu_list_t *prev = cur->prev;
+        if (prev == NULL && menu->item->last != NULL)
+            prev = menu->item->last;
+        if (prev == NULL || prev == item)
+            break;
+        covers[ci].game = prev;
+        cur = prev;
+    }
+
+    // Populate right, walk forwards from center
+    cur = item;
+    for (ci = centerIndex + 1; ci < coverCount; ci++) {
+        submenu_list_t *next = cur->next;
+        if (next == NULL)
+            next = menu->item->submenu;
+        if (next == NULL || next == item)
+            break;
+        covers[ci].game = next;
+        cur = next;
+    }
 
     float eased = 1.0f;
     float animOffset = 0.0f;
     if (isAnimating) {
-        clock_t elapsed = clock() - animationStartTime;
-        float t = (float)elapsed / ((float)COVERFLOW_ANIM_DURATION_MS * CLOCKS_PER_SEC / 1000);
-
-        if (t >= 1.0f) {
-            t = 1.0f;
+        if (gCoverflowAnimSpeed <= 0) {
             isAnimating = 0;
-            animationStartTime = 0;
-        }
+        } else {
+            clock_t elapsed = clock() - animationStartTime;
+            float t = (float)elapsed / ((float)gCoverflowAnimSpeed * CLOCKS_PER_SEC / 1000);
 
-        float inv = 1.0f - t;
-        eased = 1.0f - inv * inv * inv;
-        animOffset = (float)animationDirection * (float)coverDistance * (eased - 1.0f);
+            if (t >= 1.0f) {
+                t = 1.0f;
+                isAnimating = 0;
+                animationStartTime = 0;
+            }
+
+            float inv = 1.0f - t;
+            eased = 1.0f - inv * inv * inv;
+            animOffset = (float)animationDirection * (float)coverDistance * (eased - 1.0f);
+        }
     }
 
     int posX = basePosX + (int)animOffset;
+    int scaling = gCoverflowCenterScale;
 
-    int scaling = 30;
-    // direction=-1 (next): covers[2] is visually at center at t=0
-    // direction=1 (prev): covers[0] is visually at center at t=0
-    int leavingIndex = (animationDirection > 0) ? 2 : 0;
+    // direction=-1 (next): covers[centerIndex - 1] is visually at center at t=0
+    // direction=1 (prev): covers[centerIndex + 1] is visually at center at t=0
+    int leavingIndex = (animationDirection > 0) ? (centerIndex + 1) : (centerIndex - 1);
 
-    for (int i = 0; i < COVERFLOW_COUNT; i++) {
+    for (int i = 0; i < coverCount; i++) {
         int renderPosX = posX;
         posX += coverDistance;
 
@@ -1134,7 +1177,10 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         mutable_image_t *img = (mutable_image_t *)coverElem->extended;
         item_list_t *sourceList = thmGetItemSource(menu, covers[i].game);
 
-        int baseCoverHeight = (coverElem != elem && coverElem->height != DIM_UNDEF) ? coverElem->height : coverHeight;
+        int baseCoverHeight = coverHeight;
+        if (coverElem != elem && coverElem->height != DIM_UNDEF)
+            baseCoverHeight = (int)(coverElem->height * coverScaleRatio);
+
         int currentCoverWidth = coverWidth;
         int currentCoverHeight = baseCoverHeight;
         int overlayOffsetY = 0;
@@ -1142,7 +1188,7 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
 
         // Interpolate scaling.. center cover grows in.. leaving cover shrinks out
         int currentScaling = 0;
-        if (i == 1) {
+        if (i == centerIndex) {
             // New selection.. grows into center as animation progresses
             float growFactor = isAnimating ? eased : 1.0f;
             currentScaling = (int)(scaling * growFactor);
@@ -1162,7 +1208,13 @@ static void drawCoverFlow(struct menu_list *menu, struct submenu_list *item, con
         if (!covers[i].texture || !covers[i].texture->Mem)
             covers[i].texture = img->defaultTexture ? &img->defaultTexture->source : thmGetTexture(COVER_DEFAULT);
 
-        thmDrawTexture(covers[i].texture, img, renderPosX, coverElem->posY, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, gDefaultCol, elem->reflection, overlayOffsetX, overlayOffsetY);
+        u64 coverColor = gDefaultCol;
+        if (gCoverflowDimCovers && i != centerIndex)
+            coverColor = GS_SETREG_RGBA(0x80, 0x80, 0x80, 0x40);
+
+        int thisCoverYOffset = (coverElem != elem && coverElem->height != DIM_UNDEF) ? (coverElem->height - baseCoverHeight) / 2 : coverYOffset;
+
+        thmDrawTexture(covers[i].texture, img, renderPosX, coverElem->posY + thisCoverYOffset, ALIGN_CENTER, currentCoverWidth, currentCoverHeight, SCALING_NONE, coverColor, elem->reflection, overlayOffsetX, overlayOffsetY, coverScaleRatio);
     }
 }
 
@@ -1528,6 +1580,7 @@ static void thmLoad(const char *themePath, int themeID)
     newT->logoIcon = NULL;
     newT->logoIconCount = LOGO_21 - LOGO_01 + 1;
     newT->coverflow = NULL;
+    newT->coverflowCoverOffset = 0;
 
     config_set_t *themeConfig = NULL;
     if (!themePath && themeID == 0) {
@@ -1681,6 +1734,7 @@ static void thmLoad(const char *themePath, int themeID)
     } else
         texLoadInternal(&newT->textures[SETTINGS_BG], SETTINGS_BG);
 
+    configGetInt(themeConfig, "coverflow_cover_offset", &newT->coverflowCoverOffset);
 
     configFree(themeConfig);
     gTheme = newT;


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Alright I think this is finally ready..
Added coverflow options for themes that use type=coverflow:
Cover count - 3 or 5, Animation Speed, Selected cover scale and Unselected dimming.

Had to add a new cfg entry: coverflow_cover_offset .. because the calculations set the positioning wrong if your overlay image has transparency on the canvas and your image isn't centered. Take the internal case for example, to the right of the case is 29px of alpha, 29 / 2 = 14.5 so coverflow_cover_offset=14 compensates for the alpha and shifts it into the correct position.. if your image was to the right of the canvas it would be minus eg -n(px/2) or in our case -14 etc

Please test on real HW and let me know if any issues occur.

<img width="435" height="294" alt="Screenshot 2026-06-02 173258" src="https://github.com/user-attachments/assets/065e6ed0-f1ac-4376-ba23-d58e8cf5b8a8" />

<img width="422" height="303" alt="Screenshot 2026-06-02 173243" src="https://github.com/user-attachments/assets/fdf7f1e0-3eea-48b7-bda3-b8c9152dcac5" />