### PR TITLE
fix sending game id to mmce

### DIFF
--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -24,8 +24,8 @@ extern char gMMCEPrefix[32];
 
 void mmceInit(item_list_t *itemList);
 item_list_t *mmceGetObject(int initOnly);
+void mmceSendGameId(const char *gameId);
 void mmceLoadModules(void);
 void mmceLaunchGame(item_list_t *itemList, int fd, config_set_t *configSet);
-
 
 #endif

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -82,6 +82,7 @@ file_buffer_t *sbOpenFileBuffer(char *fpath, int mode, short allocResult, unsign
 int sbReadFileBuffer(file_buffer_t *readContext, char **outBuf);
 void sbWriteFileBuffer(file_buffer_t *fileBuffer, char *inBuf, int size);
 void sbCloseFileBuffer(file_buffer_t *fileBuffer);
+void sbMMCESendGameId(const char *gameId);
 
 // ISO9660 filesystem management functions.
 u32 sbGetISO9660MaxLBA(const char *path);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -612,6 +612,8 @@ void bdmLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
     }
 
+    sbMMCESendGameId(game->startup);
+
     if (gAutoLaunchBDMGame == NULL)
         deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
     else {

--- a/src/ethsupport.c
+++ b/src/ethsupport.c
@@ -744,6 +744,9 @@ static void ethLaunchGame(item_list_t *itemList, int id, config_set_t *configSet
 
     if (configGetStrCopy(configSet, CONFIG_ITEM_ALTSTARTUP, filename, sizeof(filename)) == 0)
         strcpy(filename, game->startup);
+
+    sbMMCESendGameId(game->startup);
+
     deinit(NO_EXCEPTION, ETH_MODE); // CAREFUL: deinit will call ethCleanUp, so ethGames/game will be freed
 
     settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1114,6 +1114,8 @@ void hddLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
         }
     }
 
+    sbMMCESendGameId(game->startup);
+
     if (gAutoLaunchGame == NULL)
         deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
     else {

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -96,6 +96,40 @@ void mmceInit(item_list_t *itemList)
     mmceGameList.enabled = 1;
 }
 
+void mmceSendGameId(const char *gameId)
+{
+    if (!gameId || !gameId[0])
+        return;
+
+    // probe and set device
+    const char *dev = NULL;
+    if (fileXioDevctl("mmce0:/", 0x1, NULL, 0, NULL, 0) != -1)
+        dev = "mmce0:/";
+    else if (fileXioDevctl("mmce1:/", 0x1, NULL, 0, NULL, 0) != -1)
+        dev = "mmce1:/";
+    else
+        return;
+
+    // small delay to let config write before sending game id (remember last game)
+    usleep(200000); // 200 ms
+
+    // send game id to mmce
+    if (fileXioDevctl(dev, 0x8, (void *)gameId, (strlen(gameId) + 1), NULL, 0) < 0)
+        return;
+
+    // wait for busy bit clear 2 seconds 100ms poll
+    for (int i = 0; i < 20; i++) {
+        usleep(100000);
+
+        int status = fileXioDevctl(dev, 0x2, NULL, 0, NULL, 0);
+        if (status < 0)
+            break;
+
+        if ((status & 1) == 0)
+            return; // ready
+    }
+}
+
 item_list_t *mmceGetObject(int initOnly)
 {
     if (initOnly && !mmceGameList.enabled)
@@ -356,27 +390,6 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
     LOG("name: %s\n", game->name);
     LOG("start: %s\n", game->startup);
 
-    // Set gameid and poll card until ready
-#ifdef __DEBUG
-    if (gMMCEEnableGameID) {
-#endif
-
-        // Send GameID to MMCE
-        fileXioDevctl(mmcePrefix, 0x8, game->startup, (strlen(game->startup) + 1), NULL, 0);
-
-        for (int i = 0; i < 15; i++) {
-            sleep(1);
-
-            // Poll MMCE status until busy bit is clear
-            if ((fileXioDevctl(mmcePrefix, 0x2, NULL, 0, NULL, 0) & 1) == 0) {
-                LOG("Set MMCE GameID to: %s\n", game->startup);
-                break;
-            }
-        }
-#ifdef __DEBUG
-    }
-#endif
-
     int coreLoader = 0;
     configGetInt(configSet, CONFIG_ITEM_CORE_LOADER, &coreLoader);
 
@@ -395,6 +408,8 @@ void mmceLaunchGame(item_list_t *itemList, int id, config_set_t *configSet)
 
     // mcReset();
     // mcInit(MC_TYPE_XMC);
+
+    mmceSendGameId(game->startup);
 
     if (gAutoLaunchBDMGame == NULL)
         deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -17,6 +17,7 @@
 #include "include/gui.h"
 #include "include/bdmsupport.h"
 #include "include/hddsupport.h"
+#include "include/mmcesupport.h"
 #include "include/tar.h"
 
 #define NEWLIB_PORT_AWARE
@@ -523,6 +524,11 @@ void sbCloseFileBuffer(file_buffer_t *fileBuffer)
     }
     free(fileBuffer->buffer);
     free(fileBuffer);
+}
+
+void sbMMCESendGameId(const char *gameId)
+{
+    mmceSendGameId(gameId);
 }
 
 static int GetStartupExecName(const char *path, char *filename, int maxlength)


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description

fixes mmce game id switching per device

configurations tested:
mc0 = mmce

result: game id switches from hdd/mmce

mc0 = fmcb magicgate card
mc1 = mmce (mmce mode off)

result: game id does not send

mc0 = fmcb magicgate card
mc1 = mmce (mmce mode on)

result: game id sends and switches

mc0 = fmcb magicgate card
mc1 = empty (no mmce)

result: config saves as normal on mc0 (remember last played)

between all tests there were no noticeable delays added