### PR TITLE
Neutrino support update

### DIFF
--- a/include/config_wopl.h
+++ b/include/config_wopl.h
@@ -9,6 +9,9 @@
 #define CONFIG_GAME    16
 #define CONFIG_ALL     (CONFIG_OPL | CONFIG_NETWORK | CONFIG_GAME)
 
+#define CORE_LOADER_WOPL     0
+#define CORE_LOADER_NEUTRINO 1
+
 extern int gBDMFramesDelay;
 extern int gETHFramesDelay;
 extern int gHDDFramesDelay;

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -42,6 +42,12 @@ typedef struct
     short allocResult;
 } file_buffer_t;
 
+typedef struct
+{
+    char elf[256];
+    char cwd[256];
+} neutrino_path_t;
+
 #ifdef PADEMU
 extern int gEnablePadEmu;
 extern int gPadEmuSettings;
@@ -88,5 +94,7 @@ int sbProbeISO9660_64(const char *path, base_game_info_t *game, u32 layer1_offse
 int sbLoadCheats(const char *path, const char *file);
 int sbLoadImage(const char *path, const char *file);
 #endif
+
+const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix);
 
 #endif

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -95,7 +95,10 @@ int sbLoadCheats(const char *path, const char *file);
 int sbLoadImage(const char *path, const char *file);
 #endif
 
-const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix);
+int sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix);
 void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const char *vmc);
+
+int sbGetPathMode(const char *path);
+int sbPathIsMC(const char *path);
 
 #endif

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -96,5 +96,6 @@ int sbLoadImage(const char *path, const char *file);
 #endif
 
 const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix);
+void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const char *vmc);
 
 #endif

--- a/include/system.h
+++ b/include/system.h
@@ -3,9 +3,6 @@
 
 #include "include/mcemu.h"
 
-#define NEUTRINO_PATH     "mc0:NEUTRINO/neutrino.elf"
-#define NEUTRINO_ALT_PATH "mc1:NEUTRINO/neutrino.elf"
-
 extern int gOSDLanguageValue;
 extern int gOSDTVAspectRatio;
 extern int gOSDVideOutput;
@@ -34,7 +31,7 @@ void sysInitPadEmu(void);
 #endif
 
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags);
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath);
+void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd);
 
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);
 int sysCheckMC(void);

--- a/include/system.h
+++ b/include/system.h
@@ -31,7 +31,7 @@ void sysInitPadEmu(void);
 #endif
 
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags);
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd);
+void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd, const char *vmc0, const char *vmc1);
 
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);
 int sysCheckMC(void);

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -67,7 +67,6 @@ static int oplScanApps(int (*callback)(const char *path, config_t *appConfig, vo
 
 static int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
 static int oplShouldAppsUpdate(void);
-static int oplPath2Mode(const char *path);
 
 static float appGetELFSize(char *path)
 {
@@ -297,7 +296,7 @@ static void appLaunchItem(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         close(fd);
 
         strcpy(partition, "");
-        mode = oplPath2Mode(filename);
+        mode = sbGetPathMode(filename);
         if (mode < 0)
             mode = APP_MODE;
 
@@ -535,7 +534,7 @@ static int oplGetAppImage(const char *device, char *folder, int isRelative, char
 
     elfbootmode = -1;
     if (device != NULL) {
-        elfbootmode = oplPath2Mode(device);
+        elfbootmode = sbGetPathMode(device);
         if (elfbootmode >= 0) {
             listSupport = list_support[elfbootmode].support;
 
@@ -573,31 +572,4 @@ static int oplShouldAppsUpdate(void)
     shouldAppsUpdate = 0;
 
     return result;
-}
-
-// For resolving the mode, given an app's path
-static int oplPath2Mode(const char *path)
-{
-    char appsPath[64];
-    const char *blkdevnameend;
-    int i, blkdevnamelen;
-    item_list_t *listSupport;
-
-    for (i = 0; i < MODE_COUNT; i++) {
-        listSupport = list_support[i].support;
-        if ((listSupport != NULL) && (listSupport->itemGetPrefix != NULL)) {
-            char *prefix = listSupport->itemGetPrefix(listSupport);
-            snprintf(appsPath, sizeof(appsPath), "%sAPPS", prefix);
-
-            blkdevnameend = strchr(appsPath, ':');
-            if (blkdevnameend != NULL) {
-                blkdevnamelen = (int)(blkdevnameend - appsPath);
-
-                if (strncmp(path, appsPath, blkdevnamelen) == 0)
-                    return listSupport->mode;
-            }
-        }
-    }
-
-    return -1;
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -620,14 +620,14 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     int coreLoader = 0;
     coreLoader = pgcfg->core_loader;
 
-    const char *neutrinoPath = NULL;
+    neutrino_path_t neutrinoPath;
+    const char *neutrinoElf = NULL;
     if (coreLoader) {
-        neutrinoPath = sbFileExists(NEUTRINO_PATH) ? NEUTRINO_PATH : (sbFileExists(NEUTRINO_ALT_PATH) ? NEUTRINO_ALT_PATH : NULL);
-
+        neutrinoElf = sbFindNeutrino(&neutrinoPath, pDeviceData->bdmPrefix);
         if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
             guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
             coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
+        } else if (neutrinoElf == NULL) {
             guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
             coreLoader = 0;
         }
@@ -650,7 +650,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     LOG("bdm pre sysLaunchLoaderElf\n");
 
     if (coreLoader) {
-        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoPath);
+        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd);
         return;
     }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -400,77 +400,106 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         game = gAutoLaunchBDMGame;
     }
 
-    char vmc_name[32], vmc_path[256], have_error = 0;
-    int vmc_id, size_mcemu_irx = 0;
-    bdm_vmc_infos_t bdm_vmc_infos;
-    vmc_superblock_t vmc_superblock;
+    int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
 
-    for (vmc_id = 0; vmc_id < 2; vmc_id++) {
-        memset(&bdm_vmc_infos, 0, sizeof(bdm_vmc_infos_t));
-        strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
-        vmc_name[sizeof(vmc_name) - 1] = '\0';
-        if (vmc_name[0]) {
-            have_error = 1;
-            int vmcSizeInMb = sysCheckVMC(pDeviceData->bdmPrefix, "/", vmc_name, 0, &vmc_superblock);
-            if (vmcSizeInMb > 0) {
-                bdm_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
-                bdm_vmc_infos.flags |= 0x100;
-                bdm_vmc_infos.specs.page_size = vmc_superblock.page_size;
-                bdm_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
-                bdm_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+    neutrino_path_t neutrinoPath;
+    const char *neutrinoElf = NULL;
+    char neutrinoVmc0[256];
+    char neutrinoVmc1[256];
 
-                sprintf(vmc_path, "%sVMC/%s.bin", pDeviceData->bdmPrefix, vmc_name);
+    neutrinoPath.elf[0] = '\0';
+    neutrinoPath.cwd[0] = '\0';
+    neutrinoVmc0[0] = '\0';
+    neutrinoVmc1[0] = '\0';
 
-                fd = open(vmc_path, O_RDONLY);
-                if (fd >= 0) {
-                    iop_fd = ps2sdk_get_iop_fd(fd);
-                    if (fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) == 0 && (startCluster = (unsigned int)fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
-
-                        // VMC only supports 32bit LBAs at the moment, so if the starting LBA + size of the VMC crosses the 32bit boundary
-                        // just report the VMC as being fragmented to prevent file system corruption.
-                        int vmcSectorCount = vmcSizeInMb * ((1024 * 1024) / 512); // size in MB * sectors per MB
-                        if (startingLBA + vmcSectorCount > 0x100000000) {
-                            LOG("BDMSUPPORT VMC bad LBA range\n");
-                            have_error = 2;
-                        }
-                        // Check VMC cluster chain for fragmentation (write operation can cause damage to the filesystem).
-                        else if (fileXioIoctl(iop_fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
-                            LOG("BDMSUPPORT Cluster Chain OK\n");
-                            have_error = 0;
-                            bdm_vmc_infos.active = 1;
-                            bdm_vmc_infos.start_sector = (u32)startingLBA;
-                            LOG("BDMSUPPORT VMC slot %d start: 0x%X\n", vmc_id, (u32)startingLBA);
-                        } else {
-                            LOG("BDMSUPPORT Cluster Chain NG\n");
-                            have_error = 2;
-                        }
-                    }
-
-                    close(fd);
-                }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
+            guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
+            selectedCore = CORE_LOADER_WOPL;
+        } else {
+            neutrinoElf = sbFindNeutrino(&neutrinoPath, pDeviceData->bdmPrefix);
+            if (neutrinoElf == NULL) {
+                guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
+                selectedCore = CORE_LOADER_WOPL;
             }
         }
+    }
 
-        if (gAutoLaunchBDMGame == NULL) {
-            if (have_error) {
-                char error[256];
-                if (have_error == 2) // VMC file is fragmented
-                    snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name, (vmc_id + 1));
-                else
-                    snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name, (vmc_id + 1));
-                if (!guiMsgBox(error, 1, NULL)) {
-                    return;
+    int size_mcemu_irx = 0;
+
+    if (selectedCore == CORE_LOADER_WOPL) {
+        char vmc_name[32], vmc_path[256], have_error = 0;
+        int vmc_id;
+        bdm_vmc_infos_t bdm_vmc_infos;
+        vmc_superblock_t vmc_superblock;
+
+        for (vmc_id = 0; vmc_id < 2; vmc_id++) {
+            memset(&bdm_vmc_infos, 0, sizeof(bdm_vmc_infos_t));
+            strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
+            vmc_name[sizeof(vmc_name) - 1] = '\0';
+            if (vmc_name[0]) {
+                have_error = 1;
+                int vmcSizeInMb = sysCheckVMC(pDeviceData->bdmPrefix, "/", vmc_name, 0, &vmc_superblock);
+                if (vmcSizeInMb > 0) {
+                    bdm_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
+                    bdm_vmc_infos.flags |= 0x100;
+                    bdm_vmc_infos.specs.page_size = vmc_superblock.page_size;
+                    bdm_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
+                    bdm_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+
+                    sprintf(vmc_path, "%sVMC/%s.bin", pDeviceData->bdmPrefix, vmc_name);
+
+                    fd = open(vmc_path, O_RDONLY);
+                    if (fd >= 0) {
+                        iop_fd = ps2sdk_get_iop_fd(fd);
+                        if (fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) == 0 && (startCluster = (unsigned int)fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
+
+                            // VMC only supports 32bit LBAs at the moment, so if the starting LBA + size of the VMC crosses the 32bit boundary
+                            // just report the VMC as being fragmented to prevent file system corruption.
+                            int vmcSectorCount = vmcSizeInMb * ((1024 * 1024) / 512); // size in MB * sectors per MB
+                            if (startingLBA + vmcSectorCount > 0x100000000) {
+                                LOG("BDMSUPPORT VMC bad LBA range\n");
+                                have_error = 2;
+                            }
+                            // Check VMC cluster chain for fragmentation (write operation can cause damage to the filesystem).
+                            else if (fileXioIoctl(iop_fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
+                                LOG("BDMSUPPORT Cluster Chain OK\n");
+                                have_error = 0;
+                                bdm_vmc_infos.active = 1;
+                                bdm_vmc_infos.start_sector = (u32)startingLBA;
+                                LOG("BDMSUPPORT VMC slot %d start: 0x%X\n", vmc_id, (u32)startingLBA);
+                            } else {
+                                LOG("BDMSUPPORT Cluster Chain NG\n");
+                                have_error = 2;
+                            }
+                        }
+
+                        close(fd);
+                    }
                 }
             }
-        } else
-            LOG("VMC error\n");
 
-        for (i = 0; i < size_bdm_mcemu_irx; i++) {
-            if (((u32 *)&bdm_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
-                if (bdm_vmc_infos.active)
-                    size_mcemu_irx = size_bdm_mcemu_irx;
-                memcpy(&((u32 *)&bdm_mcemu_irx)[i], &bdm_vmc_infos, sizeof(bdm_vmc_infos_t));
-                break;
+            if (gAutoLaunchBDMGame == NULL) {
+                if (have_error) {
+                    char error[256];
+                    if (have_error == 2) // VMC file is fragmented
+                        snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name, (vmc_id + 1));
+                    else
+                        snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name, (vmc_id + 1));
+                    if (!guiMsgBox(error, 1, NULL)) {
+                        return;
+                    }
+                }
+            } else
+                LOG("VMC error\n");
+
+            for (i = 0; i < size_bdm_mcemu_irx; i++) {
+                if (((u32 *)&bdm_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
+                    if (bdm_vmc_infos.active)
+                        size_mcemu_irx = size_bdm_mcemu_irx;
+                    memcpy(&((u32 *)&bdm_mcemu_irx)[i], &bdm_vmc_infos, sizeof(bdm_vmc_infos_t));
+                    break;
+                }
             }
         }
     }
@@ -617,20 +646,9 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         settings->hddIsLBA48 = pDeviceData->bdmHddIsLBA48;
     }
 
-    int coreLoader = 0;
-    coreLoader = pgcfg->core_loader;
-
-    neutrino_path_t neutrinoPath;
-    const char *neutrinoElf = NULL;
-    if (coreLoader) {
-        neutrinoElf = sbFindNeutrino(&neutrinoPath, pDeviceData->bdmPrefix);
-        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
-            guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
-            coreLoader = 0;
-        } else if (neutrinoElf == NULL) {
-            guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
-            coreLoader = 0;
-        }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sbCreateNeutrinoVMCPath(neutrinoVmc0, sizeof(neutrinoVmc0), pDeviceData->bdmPrefix, pgcfg->vmc1);
+        sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), pDeviceData->bdmPrefix, pgcfg->vmc2);
     }
 
     sbMMCESendGameId(game->startup);
@@ -649,8 +667,8 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
 
     LOG("bdm pre sysLaunchLoaderElf\n");
 
-    if (coreLoader) {
-        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd);
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -403,7 +403,6 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
 
     neutrino_path_t neutrinoPath;
-    const char *neutrinoElf = NULL;
     char neutrinoVmc0[256];
     char neutrinoVmc1[256];
 
@@ -417,8 +416,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
             guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
             selectedCore = CORE_LOADER_WOPL;
         } else {
-            neutrinoElf = sbFindNeutrino(&neutrinoPath, pDeviceData->bdmPrefix);
-            if (neutrinoElf == NULL) {
+            if (!sbFindNeutrino(&neutrinoPath, pDeviceData->bdmPrefix)) {
                 guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
                 selectedCore = CORE_LOADER_WOPL;
             }
@@ -651,10 +649,23 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), pDeviceData->bdmPrefix, pgcfg->vmc2);
     }
 
-    sbMMCESendGameId(game->startup);
+    if (!(selectedCore == CORE_LOADER_NEUTRINO && sbPathIsMC(neutrinoPath.elf)))
+        sbMMCESendGameId(game->startup);
+
+    int deinitException = NO_EXCEPTION;
+    int deinitMode = itemList->mode;
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        int elfMode = sbGetPathMode(neutrinoPath.elf);
+
+        if (elfMode >= 0) {
+            deinitException = UNMOUNT_EXCEPTION;
+            deinitMode = elfMode;
+        }
+    }
 
     if (gAutoLaunchBDMGame == NULL)
-        deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
+        deinit(deinitException, deinitMode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
     else {
         miniDeinit();
 
@@ -668,7 +679,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     LOG("bdm pre sysLaunchLoaderElf\n");
 
     if (selectedCore == CORE_LOADER_NEUTRINO) {
-        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
+        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -1122,18 +1122,21 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         isZSO = 1;
     }
 
-    const char *neutrinoPath = NULL;
+    neutrino_path_t neutrinoPath;
+    const char *neutrinoElf = NULL;
     if (coreLoader) {
-        neutrinoPath = sbFileExists(NEUTRINO_PATH) ? NEUTRINO_PATH : (sbFileExists(NEUTRINO_ALT_PATH) ? NEUTRINO_ALT_PATH : NULL);
-
+        neutrinoElf = sbFindNeutrino(&neutrinoPath, gOPLPart);
         if (isZSO) {
             guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
             coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
+        } else if (neutrinoElf == NULL) {
             guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
             coreLoader = 0;
         }
     }
+
+    char partitionName[APA_IDMAX + 1];
+    snprintf(partitionName, sizeof(partitionName), "%s", game->partition_name);
 
     sbMMCESendGameId(game->startup);
 
@@ -1150,8 +1153,8 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     }
 
     if (coreLoader) {
-        LOG("partition_name=[%s] name=[%s] startup=[%s]\n", game->partition_name, game->name, game->startup);
-        sysLaunchNeutrino("apa", game->partition_name, compatMode, EnablePS2Logo, neutrinoPath);
+        LOG("partition_name=[%s]\n", partitionName);
+        sysLaunchNeutrino("apa", partitionName, compatMode, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd);
         return;
     }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -952,7 +952,6 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     int size_mcemu_irx = 0;
 
     neutrino_path_t neutrinoPath;
-    const char *neutrinoElf = NULL;
     char neutrinoVmc0[256];
     char neutrinoVmc1[256];
 
@@ -962,8 +961,7 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     neutrinoVmc1[0] = '\0';
 
     if (selectedCore == CORE_LOADER_NEUTRINO) {
-        neutrinoElf = sbFindNeutrino(&neutrinoPath, gOPLPart);
-        if (neutrinoElf == NULL) {
+        if (!sbFindNeutrino(&neutrinoPath, gOPLPart)) {
             guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
             selectedCore = CORE_LOADER_WOPL;
         }
@@ -1157,10 +1155,23 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), gOPLPart, pgcfg->vmc2);
     }
 
-    sbMMCESendGameId(game->startup);
+    if (!(selectedCore == CORE_LOADER_NEUTRINO && sbPathIsMC(neutrinoPath.elf)))
+        sbMMCESendGameId(game->startup);
+
+    int deinitException = NO_EXCEPTION;
+    int deinitMode = HDD_MODE;
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        int elfMode = sbGetPathMode(neutrinoPath.elf);
+
+        if (elfMode >= 0) {
+            deinitException = UNMOUNT_EXCEPTION;
+            deinitMode = elfMode;
+        }
+    }
 
     if (gAutoLaunchGame == NULL)
-        deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
+        deinit(deinitException, deinitMode); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
     else {
         miniDeinit();
 
@@ -1173,7 +1184,7 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
 
     if (selectedCore == CORE_LOADER_NEUTRINO) {
         LOG("partition_name=[%s]\n", partitionName);
-        sysLaunchNeutrino("apa", partitionName, compatMode, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
+        sysLaunchNeutrino("apa", partitionName, compatMode, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -947,89 +947,25 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     else
         game = gAutoLaunchGame;
 
-    apa_sub_t parts[APA_MAXSUB + 1];
-    char vmc_name[2][32];
-    int part_valid = 0, size_mcemu_irx = 0, nparts;
-    hdd_vmc_infos_t hdd_vmc_infos;
-    memset(&hdd_vmc_infos, 0, sizeof(hdd_vmc_infos_t));
+    int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
+    int isZSO = 0;
+    int size_mcemu_irx = 0;
 
-    strncpy(vmc_name[0], pgcfg->vmc1, sizeof(vmc_name[0]) - 1);
-    vmc_name[0][sizeof(vmc_name[0]) - 1] = '\0';
+    neutrino_path_t neutrinoPath;
+    const char *neutrinoElf = NULL;
+    char neutrinoVmc0[256];
+    char neutrinoVmc1[256];
 
-    strncpy(vmc_name[1], pgcfg->vmc2, sizeof(vmc_name[1]) - 1);
-    vmc_name[1][sizeof(vmc_name[1]) - 1] = '\0';
+    neutrinoPath.elf[0] = '\0';
+    neutrinoPath.cwd[0] = '\0';
+    neutrinoVmc0[0] = '\0';
+    neutrinoVmc1[0] = '\0';
 
-    if (vmc_name[0][0] || vmc_name[1][0]) {
-        nparts = hddGetPartitionInfo(gOPLPart, parts);
-        if (nparts > 0 && nparts <= 5) {
-            for (i = 0; i < nparts; i++) {
-                hdd_vmc_infos.parts[i].start = parts[i].start;
-                hdd_vmc_infos.parts[i].length = parts[i].length;
-                LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].start : 0x%X\n", i, hdd_vmc_infos.parts[i].start);
-                LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].length : 0x%X\n", i, hdd_vmc_infos.parts[i].length);
-            }
-            part_valid = 1;
-        }
-    }
-
-    if (part_valid) {
-        char vmc_path[256];
-        int vmc_id, have_error = 0;
-        vmc_superblock_t vmc_superblock;
-        pfs_blockinfo_t blocks[11];
-
-        for (vmc_id = 0; vmc_id < 2; vmc_id++) {
-            if (vmc_name[vmc_id][0]) {
-                have_error = 1;
-                hdd_vmc_infos.active = 0;
-                if (sysCheckVMC(gHDDPrefix, "/", vmc_name[vmc_id], 0, &vmc_superblock) > 0) {
-                    hdd_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
-                    hdd_vmc_infos.flags |= 0x100;
-                    hdd_vmc_infos.specs.page_size = vmc_superblock.page_size;
-                    hdd_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
-                    hdd_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
-
-                    // Check vmc inode block chain (write operation can cause damage)
-                    snprintf(vmc_path, sizeof(vmc_path), "%sVMC/%s.bin", gHDDPrefix, vmc_name[vmc_id]);
-                    if ((nparts = hddGetFileBlockInfo(vmc_path, parts, blocks, 11)) > 0) {
-                        have_error = 0;
-                        hdd_vmc_infos.active = 1;
-                        for (i = 0; i < nparts - 1; i++) {
-                            hdd_vmc_infos.blocks[i].number = blocks[i + 1].number;
-                            hdd_vmc_infos.blocks[i].subpart = blocks[i + 1].subpart;
-                            hdd_vmc_infos.blocks[i].count = blocks[i + 1].count;
-                            LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].number     : 0x%X\n", i, hdd_vmc_infos.blocks[i].number);
-                            LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].subpart    : 0x%X\n", i, hdd_vmc_infos.blocks[i].subpart);
-                            LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].count      : 0x%X\n", i, hdd_vmc_infos.blocks[i].count);
-                        }
-                    } else { // else VMC file is too fragmented
-                        LOG("HDDSUPPORT Block Chain NG\n");
-                        have_error = 2;
-                    }
-                }
-
-                if (have_error) {
-                    if (gAutoLaunchGame == NULL) {
-                        char error[256];
-                        if (have_error == 2) // VMC file is fragmented
-                            snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
-                        else
-                            snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
-                        if (!guiMsgBox(error, 1, NULL))
-                            return;
-                    } else
-                        LOG("VMC error\n");
-                }
-
-                for (i = 0; i < size_hdd_mcemu_irx; i++) {
-                    if (((u32 *)&hdd_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
-                        if (hdd_vmc_infos.active)
-                            size_mcemu_irx = size_hdd_mcemu_irx;
-                        memcpy(&((u32 *)&hdd_mcemu_irx)[i], &hdd_vmc_infos, sizeof(hdd_vmc_infos_t));
-                        break;
-                    }
-                }
-            }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        neutrinoElf = sbFindNeutrino(&neutrinoPath, gOPLPart);
+        if (neutrinoElf == NULL) {
+            guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
+            selectedCore = CORE_LOADER_WOPL;
         }
     }
 
@@ -1103,10 +1039,6 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     if (gPS2Logo)
         EnablePS2Logo = CheckPS2Logo(0, game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET);
 
-    int coreLoader = 0;
-    int isZSO = 0;
-    coreLoader = pgcfg->core_loader;
-
     // Check for ZSO to correctly adjust layer1 start
     settings->common.layer1_start = 0; // cdvdman will read it from APA header
     hddReadSectors(game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET, 1, IOBuffer);
@@ -1122,21 +1054,108 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         isZSO = 1;
     }
 
-    neutrino_path_t neutrinoPath;
-    const char *neutrinoElf = NULL;
-    if (coreLoader) {
-        neutrinoElf = sbFindNeutrino(&neutrinoPath, gOPLPart);
-        if (isZSO) {
-            guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
-            coreLoader = 0;
-        } else if (neutrinoElf == NULL) {
-            guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
-            coreLoader = 0;
+    if (selectedCore == CORE_LOADER_NEUTRINO && isZSO) {
+        guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
+        selectedCore = CORE_LOADER_WOPL;
+    }
+
+    if (selectedCore == CORE_LOADER_WOPL) {
+        apa_sub_t parts[APA_MAXSUB + 1];
+        char vmc_name[2][32];
+        int part_valid = 0, nparts;
+        hdd_vmc_infos_t hdd_vmc_infos;
+        memset(&hdd_vmc_infos, 0, sizeof(hdd_vmc_infos_t));
+
+        strncpy(vmc_name[0], pgcfg->vmc1, sizeof(vmc_name[0]) - 1);
+        vmc_name[0][sizeof(vmc_name[0]) - 1] = '\0';
+
+        strncpy(vmc_name[1], pgcfg->vmc2, sizeof(vmc_name[1]) - 1);
+        vmc_name[1][sizeof(vmc_name[1]) - 1] = '\0';
+
+        if (vmc_name[0][0] || vmc_name[1][0]) {
+            nparts = hddGetPartitionInfo(gOPLPart, parts);
+            if (nparts > 0 && nparts <= 5) {
+                for (i = 0; i < nparts; i++) {
+                    hdd_vmc_infos.parts[i].start = parts[i].start;
+                    hdd_vmc_infos.parts[i].length = parts[i].length;
+                    LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].start : 0x%X\n", i, hdd_vmc_infos.parts[i].start);
+                    LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].length : 0x%X\n", i, hdd_vmc_infos.parts[i].length);
+                }
+                part_valid = 1;
+            }
+        }
+
+        if (part_valid) {
+            char vmc_path[256];
+            int vmc_id;
+            vmc_superblock_t vmc_superblock;
+            pfs_blockinfo_t blocks[11];
+
+            for (vmc_id = 0; vmc_id < 2; vmc_id++) {
+                int have_error = 0;
+
+                if (vmc_name[vmc_id][0]) {
+                    have_error = 1;
+                    hdd_vmc_infos.active = 0;
+                    if (sysCheckVMC(gHDDPrefix, "/", vmc_name[vmc_id], 0, &vmc_superblock) > 0) {
+                        hdd_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
+                        hdd_vmc_infos.flags |= 0x100;
+                        hdd_vmc_infos.specs.page_size = vmc_superblock.page_size;
+                        hdd_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
+                        hdd_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+
+                        // Check vmc inode block chain (write operation can cause damage)
+                        snprintf(vmc_path, sizeof(vmc_path), "%sVMC/%s.bin", gHDDPrefix, vmc_name[vmc_id]);
+                        if ((nparts = hddGetFileBlockInfo(vmc_path, parts, blocks, 11)) > 0) {
+                            have_error = 0;
+                            hdd_vmc_infos.active = 1;
+                            for (i = 0; i < nparts - 1; i++) {
+                                hdd_vmc_infos.blocks[i].number = blocks[i + 1].number;
+                                hdd_vmc_infos.blocks[i].subpart = blocks[i + 1].subpart;
+                                hdd_vmc_infos.blocks[i].count = blocks[i + 1].count;
+                                LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].number     : 0x%X\n", i, hdd_vmc_infos.blocks[i].number);
+                                LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].subpart    : 0x%X\n", i, hdd_vmc_infos.blocks[i].subpart);
+                                LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].count      : 0x%X\n", i, hdd_vmc_infos.blocks[i].count);
+                            }
+                        } else { // else VMC file is too fragmented
+                            LOG("HDDSUPPORT Block Chain NG\n");
+                            have_error = 2;
+                        }
+                    }
+
+                    if (have_error) {
+                        if (gAutoLaunchGame == NULL) {
+                            char error[256];
+                            if (have_error == 2) // VMC file is fragmented
+                                snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
+                            else
+                                snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
+                            if (!guiMsgBox(error, 1, NULL))
+                                return;
+                        } else
+                            LOG("VMC error\n");
+                    }
+
+                    for (i = 0; i < size_hdd_mcemu_irx; i++) {
+                        if (((u32 *)&hdd_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
+                            if (hdd_vmc_infos.active)
+                                size_mcemu_irx = size_hdd_mcemu_irx;
+                            memcpy(&((u32 *)&hdd_mcemu_irx)[i], &hdd_vmc_infos, sizeof(hdd_vmc_infos_t));
+                            break;
+                        }
+                    }
+                }
+            }
         }
     }
 
     char partitionName[APA_IDMAX + 1];
     snprintf(partitionName, sizeof(partitionName), "%s", game->partition_name);
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sbCreateNeutrinoVMCPath(neutrinoVmc0, sizeof(neutrinoVmc0), gOPLPart, pgcfg->vmc1);
+        sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), gOPLPart, pgcfg->vmc2);
+    }
 
     sbMMCESendGameId(game->startup);
 
@@ -1152,9 +1171,9 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
     }
 
-    if (coreLoader) {
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
         LOG("partition_name=[%s]\n", partitionName);
-        sysLaunchNeutrino("apa", partitionName, compatMode, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd);
+        sysLaunchNeutrino("apa", partitionName, compatMode, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -408,14 +408,14 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     int coreLoader = 0;
     coreLoader = pgcfg->core_loader;
 
-    const char *neutrinoPath = NULL;
+    neutrino_path_t neutrinoPath;
+    const char *neutrinoElf = NULL;
     if (coreLoader) {
-        neutrinoPath = sbFileExists(NEUTRINO_PATH) ? NEUTRINO_PATH : (sbFileExists(NEUTRINO_ALT_PATH) ? NEUTRINO_ALT_PATH : NULL);
-
+        neutrinoElf = sbFindNeutrino(&neutrinoPath, mmcePrefix);
         if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
             guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
             coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
+        } else if (neutrinoElf == NULL) {
             guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
             coreLoader = 0;
         }
@@ -438,7 +438,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     }*/
 
     if (coreLoader) {
-        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoPath);
+        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd);
         return;
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -261,11 +261,38 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     u32 layer1_start, layer1_offset;
     unsigned short int layer1_part;
 
-    // No Autolaunch yet
-    if (gAutoLaunchBDMGame == NULL)
+    /* No Autolaunch yet
+    if (gAutoLaunchMMCEGame == NULL)
         game = &mmceGames[id];
     else
-        game = gAutoLaunchBDMGame;
+        game = gAutoLaunchMMCEGame;*/
+
+    game = &mmceGames[id];
+
+    int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
+
+    neutrino_path_t neutrinoPath;
+    const char *neutrinoElf = NULL;
+    char neutrinoVmc0[256];
+    char neutrinoVmc1[256];
+
+    neutrinoPath.elf[0] = '\0';
+    neutrinoPath.cwd[0] = '\0';
+    neutrinoVmc0[0] = '\0';
+    neutrinoVmc1[0] = '\0';
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
+            guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
+            selectedCore = CORE_LOADER_WOPL;
+        } else {
+            neutrinoElf = sbFindNeutrino(&neutrinoPath, mmcePrefix);
+            if (neutrinoElf == NULL) {
+                guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
+                selectedCore = CORE_LOADER_WOPL;
+            }
+        }
+    }
 
     void *irx = &mmce_cdvdman_irx;
     int irx_size = size_mmce_cdvdman_irx;
@@ -274,43 +301,47 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     if (settings == NULL)
         return;
 
-    char vmc_name[32];
-    char vmc_path[256];
-    int vmc_size_mb;
-    int vmc_id, size_mcemu_irx = 0;
-    int vmc_fd;
-    mmce_vmc_infos_t mmce_vmc_infos;
-    vmc_superblock_t vmc_superblock;
+    int size_mcemu_irx = 0;
 
-    for (vmc_id = 0; vmc_id < 2; vmc_id++) {
-        memset(&mmce_vmc_infos, 0, sizeof(mmce_vmc_infos));
-        strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
-        vmc_name[sizeof(vmc_name) - 1] = '\0';
-        if (vmc_name[0]) {
-            vmc_size_mb = sysCheckVMC(mmcePrefix, "/", vmc_name, 0, &vmc_superblock);
-            if (vmc_size_mb > 0) {
-                mmce_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
-                mmce_vmc_infos.flags |= 0x100;
-                mmce_vmc_infos.specs.page_size = vmc_superblock.page_size;
-                mmce_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
-                mmce_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+    if (selectedCore == CORE_LOADER_WOPL) {
+        char vmc_name[32];
+        char vmc_path[256];
+        int vmc_size_mb;
+        int vmc_id;
+        int vmc_fd;
+        mmce_vmc_infos_t mmce_vmc_infos;
+        vmc_superblock_t vmc_superblock;
 
-                sprintf(vmc_path, "%sVMC/%s.bin", mmcePrefix, vmc_name);
+        for (vmc_id = 0; vmc_id < 2; vmc_id++) {
+            memset(&mmce_vmc_infos, 0, sizeof(mmce_vmc_infos));
+            strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
+            vmc_name[sizeof(vmc_name) - 1] = '\0';
+            if (vmc_name[0]) {
+                vmc_size_mb = sysCheckVMC(mmcePrefix, "/", vmc_name, 0, &vmc_superblock);
+                if (vmc_size_mb > 0) {
+                    mmce_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
+                    mmce_vmc_infos.flags |= 0x100;
+                    mmce_vmc_infos.specs.page_size = vmc_superblock.page_size;
+                    mmce_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
+                    mmce_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
 
-                vmc_fd = fileXioOpen(vmc_path, 0x3, 0666);
-                if (vmc_fd >= 0) {
-                    mmce_vmc_infos.fd = fileXioIoctl2(vmc_fd, 0x80, NULL, 0, NULL, 0);
-                    mmce_vmc_infos.active = 1;
+                    sprintf(vmc_path, "%sVMC/%s.bin", mmcePrefix, vmc_name);
+
+                    vmc_fd = fileXioOpen(vmc_path, 0x3, 0666);
+                    if (vmc_fd >= 0) {
+                        mmce_vmc_infos.fd = fileXioIoctl2(vmc_fd, 0x80, NULL, 0, NULL, 0);
+                        mmce_vmc_infos.active = 1;
+                    }
                 }
             }
-        }
 
-        for (i = 0; i < size_mmce_mcemu_irx; i++) {
-            if (((u32 *)&mmce_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
-                if (mmce_vmc_infos.active)
-                    size_mcemu_irx = size_mmce_mcemu_irx;
-                memcpy(&((u32 *)&mmce_mcemu_irx)[i], &mmce_vmc_infos, sizeof(mmce_vmc_infos_t));
-                break;
+            for (i = 0; i < size_mmce_mcemu_irx; i++) {
+                if (((u32 *)&mmce_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
+                    if (mmce_vmc_infos.active)
+                        size_mcemu_irx = size_mmce_mcemu_irx;
+                    memcpy(&((u32 *)&mmce_mcemu_irx)[i], &mmce_vmc_infos, sizeof(mmce_vmc_infos_t));
+                    break;
+                }
             }
         }
     }
@@ -405,20 +436,9 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     LOG("name: %s\n", game->name);
     LOG("start: %s\n", game->startup);
 
-    int coreLoader = 0;
-    coreLoader = pgcfg->core_loader;
-
-    neutrino_path_t neutrinoPath;
-    const char *neutrinoElf = NULL;
-    if (coreLoader) {
-        neutrinoElf = sbFindNeutrino(&neutrinoPath, mmcePrefix);
-        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
-            guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
-            coreLoader = 0;
-        } else if (neutrinoElf == NULL) {
-            guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
-            coreLoader = 0;
-        }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sbCreateNeutrinoVMCPath(neutrinoVmc0, sizeof(neutrinoVmc0), mmcePrefix, pgcfg->vmc1);
+        sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), mmcePrefix, pgcfg->vmc2);
     }
 
     // mcReset();
@@ -426,22 +446,22 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
 
     mmceSendGameId(game->startup);
 
-    if (gAutoLaunchBDMGame == NULL)
-        deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
+    deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
 
     /* No autolaunch yet
+    if (gAutoLaunchMMCEGame == NULL)
+        deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
     else {
         miniDeinit();
 
-        free(gAutoLaunchBDMGame);
-        gAutoLaunchBDMGame = NULL;
+        free(gAutoLaunchMMCEGame);
+        gAutoLaunchMMCEGame = NULL;
     }*/
 
-    if (coreLoader) {
-        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd);
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
-
 
     settings->common.zso_cache = 0;
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -272,7 +272,6 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
 
     neutrino_path_t neutrinoPath;
-    const char *neutrinoElf = NULL;
     char neutrinoVmc0[256];
     char neutrinoVmc1[256];
 
@@ -286,8 +285,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
             guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
             selectedCore = CORE_LOADER_WOPL;
         } else {
-            neutrinoElf = sbFindNeutrino(&neutrinoPath, mmcePrefix);
-            if (neutrinoElf == NULL) {
+            if (!sbFindNeutrino(&neutrinoPath, mmcePrefix)) {
                 guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
                 selectedCore = CORE_LOADER_WOPL;
             }
@@ -444,13 +442,27 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     // mcReset();
     // mcInit(MC_TYPE_XMC);
 
-    mmceSendGameId(game->startup);
+    int elfMode = -1;
 
-    deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
+    if (selectedCore == CORE_LOADER_NEUTRINO)
+        elfMode = sbGetPathMode(neutrinoPath.elf);
+
+    if (!(selectedCore == CORE_LOADER_NEUTRINO && sbPathIsMC(neutrinoPath.elf)))
+        mmceSendGameId(game->startup);
+
+    int deinitException = NO_EXCEPTION;
+    int deinitMode = MMCE_MODE;
+
+    if (selectedCore == CORE_LOADER_NEUTRINO && elfMode >= 0) {
+        deinitException = UNMOUNT_EXCEPTION;
+        deinitMode = elfMode;
+    }
+
+    deinit(deinitException, deinitMode); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
 
     /* No autolaunch yet
     if (gAutoLaunchMMCEGame == NULL)
-        deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
+        deinit(deinitException, deinitMode); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
     else {
         miniDeinit();
 
@@ -459,7 +471,7 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     }*/
 
     if (selectedCore == CORE_LOADER_NEUTRINO) {
-        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoElf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
+        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1,4 +1,3 @@
-
 #include "include/common.h"
 #include "include/lang.h"
 #include "include/util.h"
@@ -1389,3 +1388,137 @@ int sbLoadImage(const char *path, const char *file)
     return result;
 }
 #endif
+
+static int sbTryNeutrinoPath(neutrino_path_t *path, const char *cwd)
+{
+    int length;
+
+    if (!path || !cwd || !cwd[0])
+        return 0;
+
+    snprintf(path->cwd, sizeof(path->cwd), "%s", cwd);
+
+    length = strlen(path->cwd);
+    if (length <= 0 || length >= sizeof(path->cwd) - 1)
+        return 0;
+
+    if (path->cwd[length - 1] != '/') {
+        path->cwd[length++] = '/';
+        path->cwd[length] = '\0';
+    }
+
+    snprintf(path->elf, sizeof(path->elf), "%sneutrino.elf", path->cwd);
+
+    if (sbFileExists(path->elf)) {
+        LOG("SUPPORTBASE: Neutrino ELF found at '%s'\n", path->elf);
+        return 1;
+    }
+
+    path->elf[0] = '\0';
+    path->cwd[0] = '\0';
+
+    return 0;
+}
+
+/*
+ * HDD path must not use pfs0: because hddLaunchGame() deinitializes/unmounts it before launching Neutrino
+ * For +wOPL: hdd0:+wOPL/neutrino/neutrino.elf
+ * For __common: hdd0:__common/wOPL/neutrino/neutrino.elf
+ */
+const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix)
+{
+    int i;
+    char cwd[256];
+
+    if (!path)
+        return NULL;
+
+    path->elf[0] = '\0';
+    path->cwd[0] = '\0';
+
+    if (preferredPrefix && preferredPrefix[0]) {
+        if (!strncmp(preferredPrefix, "hdd0:", 5)) {
+            if (preferredPrefix[5] != '+') {
+                snprintf(cwd, sizeof(cwd), "%s/%s/neutrino", preferredPrefix, WOPL_CONFIG_NAME);
+                if (sbTryNeutrinoPath(path, cwd))
+                    return path->elf;
+
+                snprintf(cwd, sizeof(cwd), "%s/%s/NEUTRINO", preferredPrefix, WOPL_CONFIG_NAME);
+                if (sbTryNeutrinoPath(path, cwd))
+                    return path->elf;
+            }
+
+            snprintf(cwd, sizeof(cwd), "%s/neutrino", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return path->elf;
+
+            snprintf(cwd, sizeof(cwd), "%s/NEUTRINO", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return path->elf;
+        } else {
+            snprintf(cwd, sizeof(cwd), "%sneutrino", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return path->elf;
+
+            snprintf(cwd, sizeof(cwd), "%sNEUTRINO", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return path->elf;
+        }
+    }
+
+    for (i = 0; i < MAX_BDM_DEVICES; i++) {
+        snprintf(cwd, sizeof(cwd), "mass%d:/neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+
+        snprintf(cwd, sizeof(cwd), "mass%d:neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+
+        snprintf(cwd, sizeof(cwd), "mass%d:/NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+
+        snprintf(cwd, sizeof(cwd), "mass%d:NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+    }
+
+    for (i = 0; i < 2; i++) {
+        snprintf(cwd, sizeof(cwd), "mmce%d:/neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+
+        snprintf(cwd, sizeof(cwd), "mmce%d:neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+
+        snprintf(cwd, sizeof(cwd), "mmce%d:/NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+
+        snprintf(cwd, sizeof(cwd), "mmce%d:NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return path->elf;
+    }
+
+    if (sbTryNeutrinoPath(path, "mc0:NEUTRINO"))
+        return path->elf;
+
+    if (sbTryNeutrinoPath(path, "mc1:NEUTRINO"))
+        return path->elf;
+
+    if (sbTryNeutrinoPath(path, "mc0:/NEUTRINO"))
+        return path->elf;
+
+    if (sbTryNeutrinoPath(path, "mc1:/NEUTRINO"))
+        return path->elf;
+
+    if (sbTryNeutrinoPath(path, "mc0:/APPS/neutrino"))
+        return path->elf;
+
+    if (sbTryNeutrinoPath(path, "mc1:/APPS/neutrino"))
+        return path->elf;
+
+    return NULL;
+}

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1522,3 +1522,22 @@ const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix)
 
     return NULL;
 }
+
+void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const char *vmc)
+{
+    if (!path || length <= 0)
+        return;
+
+    path[0] = '\0';
+
+    if (!prefix || !prefix[0] || !vmc || !vmc[0])
+        return;
+
+    if (!strncmp(prefix, "hdd0:", 5)) {
+        if (prefix[5] != '+')
+            snprintf(path, length, "%s/%s/VMC/%s.bin", prefix, WOPL_CONFIG_NAME, vmc);
+        else
+            snprintf(path, length, "%s/VMC/%s.bin", prefix, vmc);
+    } else
+        snprintf(path, length, "%sVMC/%s.bin", prefix, vmc);
+}

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1391,7 +1391,12 @@ int sbLoadImage(const char *path, const char *file)
 
 static int sbTryNeutrinoPath(neutrino_path_t *path, const char *cwd)
 {
+    int i;
     int length;
+    const char *elfNames[] = {
+        "neutrino.elf",
+        "NEUTRINO.ELF",
+    };
 
     if (!path || !cwd || !cwd[0])
         return 0;
@@ -1407,11 +1412,13 @@ static int sbTryNeutrinoPath(neutrino_path_t *path, const char *cwd)
         path->cwd[length] = '\0';
     }
 
-    snprintf(path->elf, sizeof(path->elf), "%sneutrino.elf", path->cwd);
+    for (i = 0; i < (int)(sizeof(elfNames) / sizeof(elfNames[0])); i++) {
+        snprintf(path->elf, sizeof(path->elf), "%s%s", path->cwd, elfNames[i]);
 
-    if (sbFileExists(path->elf)) {
-        LOG("SUPPORTBASE: Neutrino ELF found at '%s'\n", path->elf);
-        return 1;
+        if (sbFileExists(path->elf)) {
+            LOG("SUPPORTBASE: Neutrino ELF found at '%s'\n", path->elf);
+            return 1;
+        }
     }
 
     path->elf[0] = '\0';
@@ -1425,13 +1432,27 @@ static int sbTryNeutrinoPath(neutrino_path_t *path, const char *cwd)
  * For +wOPL: hdd0:+wOPL/neutrino/neutrino.elf
  * For __common: hdd0:__common/wOPL/neutrino/neutrino.elf
  */
-const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix)
+int sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix)
 {
     int i;
     char cwd[256];
+    const char *mcPaths[] = {
+        "mc0:NEUTRINO",
+        "mc1:NEUTRINO",
+        "mc0:/NEUTRINO",
+        "mc1:/NEUTRINO",
+        "mc0:neutrino",
+        "mc1:neutrino",
+        "mc0:/neutrino",
+        "mc1:/neutrino",
+        "mc0:/APPS/neutrino",
+        "mc1:/APPS/neutrino",
+        "mc0:/APPS/NEUTRINO",
+        "mc1:/APPS/NEUTRINO",
+    };
 
     if (!path)
-        return NULL;
+        return 0;
 
     path->elf[0] = '\0';
     path->cwd[0] = '\0';
@@ -1441,86 +1462,73 @@ const char *sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix)
             if (preferredPrefix[5] != '+') {
                 snprintf(cwd, sizeof(cwd), "%s/%s/neutrino", preferredPrefix, WOPL_CONFIG_NAME);
                 if (sbTryNeutrinoPath(path, cwd))
-                    return path->elf;
+                    return 1;
 
                 snprintf(cwd, sizeof(cwd), "%s/%s/NEUTRINO", preferredPrefix, WOPL_CONFIG_NAME);
                 if (sbTryNeutrinoPath(path, cwd))
-                    return path->elf;
+                    return 1;
             }
 
             snprintf(cwd, sizeof(cwd), "%s/neutrino", preferredPrefix);
             if (sbTryNeutrinoPath(path, cwd))
-                return path->elf;
+                return 1;
 
             snprintf(cwd, sizeof(cwd), "%s/NEUTRINO", preferredPrefix);
             if (sbTryNeutrinoPath(path, cwd))
-                return path->elf;
+                return 1;
         } else {
             snprintf(cwd, sizeof(cwd), "%sneutrino", preferredPrefix);
             if (sbTryNeutrinoPath(path, cwd))
-                return path->elf;
+                return 1;
 
             snprintf(cwd, sizeof(cwd), "%sNEUTRINO", preferredPrefix);
             if (sbTryNeutrinoPath(path, cwd))
-                return path->elf;
+                return 1;
         }
     }
 
     for (i = 0; i < MAX_BDM_DEVICES; i++) {
         snprintf(cwd, sizeof(cwd), "mass%d:/neutrino", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
 
         snprintf(cwd, sizeof(cwd), "mass%d:neutrino", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
 
         snprintf(cwd, sizeof(cwd), "mass%d:/NEUTRINO", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
 
         snprintf(cwd, sizeof(cwd), "mass%d:NEUTRINO", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
     }
 
     for (i = 0; i < 2; i++) {
         snprintf(cwd, sizeof(cwd), "mmce%d:/neutrino", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
 
         snprintf(cwd, sizeof(cwd), "mmce%d:neutrino", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
 
         snprintf(cwd, sizeof(cwd), "mmce%d:/NEUTRINO", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
 
         snprintf(cwd, sizeof(cwd), "mmce%d:NEUTRINO", i);
         if (sbTryNeutrinoPath(path, cwd))
-            return path->elf;
+            return 1;
     }
 
-    if (sbTryNeutrinoPath(path, "mc0:NEUTRINO"))
-        return path->elf;
+    for (i = 0; i < (int)(sizeof(mcPaths) / sizeof(mcPaths[0])); i++) {
+        if (sbTryNeutrinoPath(path, mcPaths[i]))
+            return 1;
+    }
 
-    if (sbTryNeutrinoPath(path, "mc1:NEUTRINO"))
-        return path->elf;
-
-    if (sbTryNeutrinoPath(path, "mc0:/NEUTRINO"))
-        return path->elf;
-
-    if (sbTryNeutrinoPath(path, "mc1:/NEUTRINO"))
-        return path->elf;
-
-    if (sbTryNeutrinoPath(path, "mc0:/APPS/neutrino"))
-        return path->elf;
-
-    if (sbTryNeutrinoPath(path, "mc1:/APPS/neutrino"))
-        return path->elf;
-
-    return NULL;
+    return 0;
 }
 
 void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const char *vmc)
@@ -1540,4 +1548,47 @@ void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const c
             snprintf(path, length, "%s/VMC/%s.bin", prefix, vmc);
     } else
         snprintf(path, length, "%sVMC/%s.bin", prefix, vmc);
+}
+
+int sbGetPathMode(const char *path)
+{
+    const char *blkdevnameend;
+    const char *prefixend;
+    int i, blkdevnamelen, prefixlen;
+    item_list_t *listSupport;
+
+    if (!path || !path[0])
+        return -1;
+
+    if (!strncmp(path, "hdd0:", 5) || !strncmp(path, "pfs", 3))
+        return HDD_MODE;
+
+    blkdevnameend = strchr(path, ':');
+    if (blkdevnameend == NULL)
+        return -1;
+
+    blkdevnamelen = (int)(blkdevnameend - path);
+
+    for (i = 0; i < MODE_COUNT; i++) {
+        listSupport = list_support[i].support;
+        if ((listSupport != NULL) && (listSupport->itemGetPrefix != NULL)) {
+            char *prefix = listSupport->itemGetPrefix(listSupport);
+            if (prefix != NULL) {
+                prefixend = strchr(prefix, ':');
+                if (prefixend != NULL) {
+                    prefixlen = (int)(prefixend - prefix);
+
+                    if (blkdevnamelen == prefixlen && strncmp(path, prefix, blkdevnamelen) == 0)
+                        return listSupport->mode;
+                }
+            }
+        }
+    }
+
+    return -1;
+}
+
+int sbPathIsMC(const char *path)
+{
+    return path && (!strncmp(path, "mc0:", 4) || !strncmp(path, "mc1:", 4));
 }

--- a/src/system.c
+++ b/src/system.c
@@ -1202,21 +1202,30 @@ static int convertCompatmaskToModes(int compatmask)
     return atoi(result);
 }
 
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath)
+void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd)
 {
     char device[64];
+    char bsdfs[64];
     char filePath[256];
     char compatModes[64];
-    char *argv[6];
+    char cwd[256 + 5];
+    char *argv[8];
     int argc = 0;
-
     const char *deviceName = getDeviceName(driver);
+
+    argv[argc++] = (char *)neutrinoPath;
+
+    if (neutrinoCwd && neutrinoCwd[0]) {
+        snprintf(cwd, sizeof(cwd), "-cwd=%s", neutrinoCwd);
+        argv[argc++] = cwd;
+    }
+
     if (!strncmp(deviceName, "apa", 3)) {
         snprintf(device, sizeof(device), "-bsd=ata");
         argv[argc++] = device;
 
-        snprintf(device, sizeof(device), "-bsdfs=hdl");
-        argv[argc++] = device;
+        snprintf(bsdfs, sizeof(bsdfs), "-bsdfs=hdl");
+        argv[argc++] = bsdfs;
 
         snprintf(filePath, sizeof(filePath), "-dvd=hdl:%s", path);
         argv[argc++] = filePath;
@@ -1231,6 +1240,8 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
     snprintf(compatModes, sizeof(compatModes), "-gc=%d", convertCompatmaskToModes(compatmask));
     argv[argc++] = compatModes;
 
+    LOG("NEUTRINO ELF=%s\n", neutrinoPath);
+    LOG("NEUTRINO CWD=%s\n", neutrinoCwd ? neutrinoCwd : "");
     LOG("COMPAT MODE ARG=%s\n", compatModes);
     LOG("FILE PATH=%s\n", filePath);
 

--- a/src/system.c
+++ b/src/system.c
@@ -1215,13 +1215,6 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
     int argc = 0;
     const char *deviceName = getDeviceName(driver);
 
-    argv[argc++] = (char *)neutrinoPath;
-
-    if (neutrinoCwd && neutrinoCwd[0]) {
-        snprintf(cwd, sizeof(cwd), "-cwd=%s", neutrinoCwd);
-        argv[argc++] = cwd;
-    }
-
     if (!strncmp(deviceName, "apa", 3)) {
         snprintf(device, sizeof(device), "-bsd=ata");
         argv[argc++] = device;
@@ -1237,6 +1230,11 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
 
         snprintf(filePath, sizeof(filePath), "-dvd=%s", path);
         argv[argc++] = filePath;
+    }
+
+    if (neutrinoCwd && neutrinoCwd[0]) {
+        snprintf(cwd, sizeof(cwd), "-cwd=%s", neutrinoCwd);
+        argv[argc++] = cwd;
     }
 
     if (vmc0 && vmc0[0]) {

--- a/src/system.c
+++ b/src/system.c
@@ -1202,14 +1202,16 @@ static int convertCompatmaskToModes(int compatmask)
     return atoi(result);
 }
 
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd)
+void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd, const char *vmc0, const char *vmc1)
 {
     char device[64];
     char bsdfs[64];
     char filePath[256];
     char compatModes[64];
     char cwd[256 + 5];
-    char *argv[8];
+    char mc0[256 + 5];
+    char mc1[256 + 5];
+    char *argv[12];
     int argc = 0;
     const char *deviceName = getDeviceName(driver);
 
@@ -1237,11 +1239,23 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
         argv[argc++] = filePath;
     }
 
+    if (vmc0 && vmc0[0]) {
+        snprintf(mc0, sizeof(mc0), "-mc0=%s", vmc0);
+        argv[argc++] = mc0;
+    }
+
+    if (vmc1 && vmc1[0]) {
+        snprintf(mc1, sizeof(mc1), "-mc1=%s", vmc1);
+        argv[argc++] = mc1;
+    }
+
     snprintf(compatModes, sizeof(compatModes), "-gc=%d", convertCompatmaskToModes(compatmask));
     argv[argc++] = compatModes;
 
     LOG("NEUTRINO ELF=%s\n", neutrinoPath);
     LOG("NEUTRINO CWD=%s\n", neutrinoCwd ? neutrinoCwd : "");
+    LOG("VMC0=%s\n", vmc0 ? vmc0 : "");
+    LOG("VMC1=%s\n", vmc1 ? vmc1 : "");
     LOG("COMPAT MODE ARG=%s\n", compatModes);
     LOG("FILE PATH=%s\n", filePath);
 


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Since neutrino core support was added it has been updated so I have updated wOPL support for neutrino also.

Neutrino can now be discovered from the active device path where possible, with fallback searches across supported devices. The launch code now also passes Neutrino its working directory via `-cwd`, which allows Neutrino to load its config/modules relative to the discovered install location.

This also adds VMC support for Neutrino by passing selected per game VMCs through `-mc0` and `-mc1`.

## Changes

* Search for Neutrino on supported device paths, including:

  * active BDM/MMCE prefix
  * HDD OPL partition path
  * `massX`
  * `mmceX`
  * legacy memory card locations
  * `mcX:/APPS/neutrino`
* Pass `-cwd=<path>` when launching Neutrino.
* Fix Neutrino argv setup so `argv[0]` is the ELF path.
* Add separate APA `-bsdfs=hdl` argument storage instead of reusing the same buffer as `-bsd`.
* Pass VMCs to Neutrino using:

  * `-mc0=<path>`
  * `-mc1=<path>`
* Keep existing wOPL mcemu/VMC patching for the wOPL core only.

## Notes

Neutrino still falls back to the wOPL core for unsupported formats such as USBLD and ZSO.

For HDD, Neutrino paths avoid `pfs0:` because HDD cleanup happens before launching the ELF. HDD Neutrino paths are passed using `hdd0:` paths instead.

GSM support for neutrino core has not yet been added and can be done at a later date.

Should close #197, although it does work currently for some people. It should now have greater success and functionality.

Future updates will also touch some of this as we transition from `massN` to true prefix `usb1` and so on.