### PR TITLE
Neutrino Support Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ EECORE_OBJS = ee_core.o ioprp.o util.o \
 		udnl.o imgdrv.o eesync.o \
 		bdm_cdvdman.o bdm_ata_cdvdman.o IOPRP_img.o smb_cdvdman.o \
 		hdd_cdvdman.o hdd_gamestar_cdvdman.o mmce_cdvdman.o hdd_hdpro_cdvdman.o cdvdfsv.o \
-		ingame_smstcpip.o smap_ingame.o smbman.o smbinit.o
+		ingame_smstcpip.o smap_ingame.o smbman.o smbinit.o neutrino_loader.o
 
 PNG_ASSETS = load0 load1 load2 load3 load4 load5 load6 load7 usb usb_bd ilk_bd \
 	m4s_bd hdd_bd hdd eth app fav mmce fav_mark cross triangle circle square select start left right \
@@ -295,6 +295,8 @@ clean:	download_lwNBD
 	rm -fr $(MAPFILE) $(EE_BIN) $(EE_BIN_PACKED) $(EE_BIN_STRIPPED) $(EE_VPKD).* $(EE_OBJS_DIR) $(EE_ASM_DIR)
 	echo "-EE core"
 	$(MAKE) -C ee_core clean
+	echo "-NEUTRINO LOADER"
+	$(MAKE) -C neutrino_loader clean
 	echo "-IOP core"
 	echo " -imgdrv"
 	$(MAKE) -C modules/iopcore/imgdrv clean
@@ -419,6 +421,12 @@ ee_core/ee_core.elf: ee_core
 
 $(EE_ASM_DIR)ee_core.c: ee_core/ee_core.elf | $(EE_ASM_DIR)
 	$(BIN2C) $< $@ eecore_elf
+
+neutrino_loader/loader.elf: neutrino_loader/loader.c neutrino_loader/linkfile
+	$(MAKE) -C neutrino_loader
+
+$(EE_ASM_DIR)neutrino_loader.c: neutrino_loader/loader.elf | $(EE_ASM_DIR)
+	$(BIN2C) $< $@ neutrino_loader_elf
 
 $(EE_ASM_DIR)udnl.c: $(UDNL_OUT) | $(EE_ASM_DIR)
 	$(BIN2C) $(UDNL_OUT) $@ udnl_irx

--- a/include/config_wopl.h
+++ b/include/config_wopl.h
@@ -9,6 +9,9 @@
 #define CONFIG_GAME    16
 #define CONFIG_ALL     (CONFIG_OPL | CONFIG_NETWORK | CONFIG_GAME)
 
+#define CORE_LOADER_WOPL     0
+#define CORE_LOADER_NEUTRINO 1
+
 extern int gBDMFramesDelay;
 extern int gETHFramesDelay;
 extern int gHDDFramesDelay;

--- a/include/mmcesupport.h
+++ b/include/mmcesupport.h
@@ -25,6 +25,7 @@ extern char gMMCEPrefix[32];
 void mmceInit(item_list_t *itemList);
 item_list_t *mmceGetObject(int initOnly);
 void mmceSendGameId(const char *gameId);
+void mmceSendGameIdToDevice(int device, const char *gameId);
 void mmceLoadModules(void);
 void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg);
 

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -42,6 +42,12 @@ typedef struct
     short allocResult;
 } file_buffer_t;
 
+typedef struct
+{
+    char elf[256];
+    char cwd[256];
+} neutrino_path_t;
+
 #ifdef PADEMU
 extern int gEnablePadEmu;
 extern int gPadEmuSettings;
@@ -88,5 +94,12 @@ int sbProbeISO9660_64(const char *path, base_game_info_t *game, u32 layer1_offse
 int sbLoadCheats(const char *path, const char *file);
 int sbLoadImage(const char *path, const char *file);
 #endif
+
+int sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix);
+void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const char *vmc);
+
+int sbGetPathModeAndDevice(const char *path, int *device);
+int sbGetPathMode(const char *path);
+int sbPathIsMC(const char *path);
 
 #endif

--- a/include/system.h
+++ b/include/system.h
@@ -3,9 +3,6 @@
 
 #include "include/mcemu.h"
 
-#define NEUTRINO_PATH     "mc0:NEUTRINO/neutrino.elf"
-#define NEUTRINO_ALT_PATH "mc1:NEUTRINO/neutrino.elf"
-
 extern int gOSDLanguageValue;
 extern int gOSDTVAspectRatio;
 extern int gOSDVideOutput;
@@ -34,7 +31,7 @@ void sysInitPadEmu(void);
 #endif
 
 void sysLaunchLoaderElf(const char *filename, const char *mode_str, int size_cdvdman_irx, void **cdvdman_irx, int size_mcemu_irx, void **mcemu_irx, int EnablePS2Logo, unsigned int compatflags);
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath);
+void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd, const char *vmc0, const char *vmc1);
 
 int sysLoadModuleBuffer(void *buffer, int size, int argc, char *argv);
 int sysCheckMC(void);

--- a/neutrino_loader/Makefile
+++ b/neutrino_loader/Makefile
@@ -1,0 +1,19 @@
+EE_LINKFILE := linkfile
+EE_CFLAGS = -D_EE -Os -G0 -Wall
+EE_CFLAGS += -fdata-sections -ffunction-sections
+EE_LDFLAGS = -Wl,-zmax-page-size=128
+EE_LDFLAGS += -s -Wl,--gc-sections
+
+EE_BIN = loader.elf
+
+EE_OBJS = loader.o
+
+EE_LIBS =
+
+all: $(EE_BIN)
+
+clean:
+	rm -f -r $(EE_OBJS) $(EE_BIN)
+
+include $(PS2SDK)/samples/Makefile.pref
+include $(PS2SDK)/samples/Makefile.eeglobal

--- a/neutrino_loader/linkfile
+++ b/neutrino_loader/linkfile
@@ -1,0 +1,67 @@
+ENTRY(__start);
+
+MEMORY {
+	bios	: ORIGIN = 0x00000000, LENGTH = 528K /* 0x00000000 - 0x00084000: BIOS memory */
+	bram	: ORIGIN = 0x00084000, LENGTH = 496K /* 0x00084000 - 0x00100000: BIOS unused memory */
+	gram	: ORIGIN = 0x00100000, LENGTH =  31M /* 0x00100000 - 0x02000000: GAME memory */
+}
+
+REGION_ALIAS("MAIN_REGION", bram);
+
+PHDRS {
+  text PT_LOAD;
+}
+
+SECTIONS {
+	.text : {
+		*(.text)
+	} >MAIN_REGION :text
+
+	.reginfo : { *(.reginfo) } >MAIN_REGION
+
+	.ctors ALIGN(16): {
+		KEEP(*crtbegin*.o(.ctors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
+		KEEP(*(SORT(.ctors.*)))
+		KEEP(*(.ctors))
+	} >MAIN_REGION
+
+	.dtors ALIGN(16): {
+		KEEP(*crtbegin*.o(.dtors))
+		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
+		KEEP(*(SORT(.dtors.*)))
+		KEEP(*(.dtors))
+	} >MAIN_REGION
+
+	.rodata ALIGN(128): {
+		*(.rodata)
+	} >MAIN_REGION
+
+	.data ALIGN(128): {
+		_fdata = . ;
+		*(.data)
+		SORT(CONSTRUCTORS)
+	} >MAIN_REGION
+
+	_gp = ALIGN(128) + 0x7ff0;
+	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
+	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION
+
+	.sdata ALIGN(128): {
+		*(.sdata)
+	} >MAIN_REGION
+
+	.sbss ALIGN(128) : {
+		_fbss = . ;
+		*(.sbss)
+	} >MAIN_REGION
+
+	.bss ALIGN(128) : {
+		*(.bss)
+	} >MAIN_REGION
+
+	PROVIDE(_end = .);
+	PROVIDE(_heap_size = -1);
+	PROVIDE(_stack = .);
+	PROVIDE(_stack_size = ORIGIN(MAIN_REGION) + LENGTH(MAIN_REGION) - _stack);
+}

--- a/neutrino_loader/loader.c
+++ b/neutrino_loader/loader.c
@@ -1,0 +1,98 @@
+/*
+# _____     ___ ____     ___ ____
+#  ____|   |    ____|   |        | |____|
+# |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
+#-----------------------------------------------------------------------
+# (c) 2020 Francisco Javier Trujillo Mata <fjtrujy@gmail.com>
+# Licenced under Academic Free License version 2.0
+# Review ps2sdk README & LICENSE files for further details.
+#
+*/
+
+#include <kernel.h>
+#include <loadfile.h>
+#include <ps2sdkapi.h>
+#include <sifrpc.h>
+#include <string.h>
+
+// Reduce binary size: these are weak in libc/src/init.c
+void _libcglue_init() {}
+void _libcglue_deinit() {}
+void _libcglue_args_parse(int argc, char **argv) {}
+
+DISABLE_PATCHED_FUNCTIONS();
+DISABLE_EXTRA_TIMERS_FUNCTIONS();
+PS2_DISABLE_AUTOSTART_PTHREAD();
+
+// Clear user memory (PS2Link (C) 2003 Tord Lindstrom / adresd)
+static void wipeUserMem(void)
+{
+    int i;
+    for (i = 0x100000; i < GetMemorySize(); i += 64) {
+        asm volatile("\tsq $0, 0(%0) \n"
+                     "\tsq $0, 16(%0) \n"
+                     "\tsq $0, 32(%0) \n"
+                     "\tsq $0, 48(%0) \n" ::"r"(i));
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    static t_ExecData elfdata;
+    int ret, i;
+
+    elfdata.epc = 0;
+
+    // argv[0] = partition/prefix, or ""
+    // argv[1] = path to ELF
+    if (argc < 2)
+        return -EINVAL;
+
+    char *new_argv[argc - 1];
+    int fullPath_length = 1 + strlen(argv[0]) + strlen(argv[1]);
+    char fullPath[fullPath_length];
+
+    strcpy(fullPath, argv[0]);
+    strcat(fullPath, argv[1]);
+
+    // final new_argv[0] is partition + path to ELF
+    new_argv[0] = fullPath;
+
+    for (i = 2; i < argc; i++)
+        new_argv[i - 1] = argv[i];
+
+    SifInitRpc(0);
+
+    wipeUserMem();
+
+    FlushCache(0);
+
+    SifLoadFileInit();
+    ret = SifLoadElf(argv[1], &elfdata);
+    SifLoadFileExit();
+
+    if (ret == 0 && elfdata.epc != 0) {
+        /*
+         * Removed iopreset
+         *
+         * while(!SifIopReset(NULL, 0)){};
+         * while(!SifIopSync()){};
+         * SifInitRpc(0);
+         * SifLoadFileInit();
+         * SifLoadModule("rom0:SIO2MAN", 0, NULL);
+         * SifLoadModule("rom0:MCMAN", 0, NULL);
+         * SifLoadModule("rom0:MCSERV", 0, NULL);
+         * SifLoadFileExit();
+         */
+
+        SifExitRpc();
+
+        FlushCache(0);
+        FlushCache(2);
+
+        return ExecPS2((void *)elfdata.epc, (void *)elfdata.gp, argc - 1, new_argv);
+    } else {
+        SifExitRpc();
+        return -ENOENT;
+    }
+}

--- a/src/appsupport.c
+++ b/src/appsupport.c
@@ -67,7 +67,6 @@ static int oplScanApps(int (*callback)(const char *path, config_t *appConfig, vo
 
 static int oplGetAppImage(const char *device, char *folder, int isRelative, char *value, char *suffix, GSTEXTURE *resultTex, short psm);
 static int oplShouldAppsUpdate(void);
-static int oplPath2Mode(const char *path);
 
 static float appGetELFSize(char *path)
 {
@@ -297,7 +296,7 @@ static void appLaunchItem(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         close(fd);
 
         strcpy(partition, "");
-        mode = oplPath2Mode(filename);
+        mode = sbGetPathMode(filename);
         if (mode < 0)
             mode = APP_MODE;
 
@@ -535,7 +534,7 @@ static int oplGetAppImage(const char *device, char *folder, int isRelative, char
 
     elfbootmode = -1;
     if (device != NULL) {
-        elfbootmode = oplPath2Mode(device);
+        elfbootmode = sbGetPathMode(device);
         if (elfbootmode >= 0) {
             listSupport = list_support[elfbootmode].support;
 
@@ -573,31 +572,4 @@ static int oplShouldAppsUpdate(void)
     shouldAppsUpdate = 0;
 
     return result;
-}
-
-// For resolving the mode, given an app's path
-static int oplPath2Mode(const char *path)
-{
-    char appsPath[64];
-    const char *blkdevnameend;
-    int i, blkdevnamelen;
-    item_list_t *listSupport;
-
-    for (i = 0; i < MODE_COUNT; i++) {
-        listSupport = list_support[i].support;
-        if ((listSupport != NULL) && (listSupport->itemGetPrefix != NULL)) {
-            char *prefix = listSupport->itemGetPrefix(listSupport);
-            snprintf(appsPath, sizeof(appsPath), "%sAPPS", prefix);
-
-            blkdevnameend = strchr(appsPath, ':');
-            if (blkdevnameend != NULL) {
-                blkdevnamelen = (int)(blkdevnameend - appsPath);
-
-                if (strncmp(path, appsPath, blkdevnamelen) == 0)
-                    return listSupport->mode;
-            }
-        }
-    }
-
-    return -1;
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -400,77 +400,104 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         game = gAutoLaunchBDMGame;
     }
 
-    char vmc_name[32], vmc_path[256], have_error = 0;
-    int vmc_id, size_mcemu_irx = 0;
-    bdm_vmc_infos_t bdm_vmc_infos;
-    vmc_superblock_t vmc_superblock;
+    int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
 
-    for (vmc_id = 0; vmc_id < 2; vmc_id++) {
-        memset(&bdm_vmc_infos, 0, sizeof(bdm_vmc_infos_t));
-        strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
-        vmc_name[sizeof(vmc_name) - 1] = '\0';
-        if (vmc_name[0]) {
-            have_error = 1;
-            int vmcSizeInMb = sysCheckVMC(pDeviceData->bdmPrefix, "/", vmc_name, 0, &vmc_superblock);
-            if (vmcSizeInMb > 0) {
-                bdm_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
-                bdm_vmc_infos.flags |= 0x100;
-                bdm_vmc_infos.specs.page_size = vmc_superblock.page_size;
-                bdm_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
-                bdm_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+    neutrino_path_t neutrinoPath;
+    char neutrinoVmc0[256];
+    char neutrinoVmc1[256];
 
-                sprintf(vmc_path, "%sVMC/%s.bin", pDeviceData->bdmPrefix, vmc_name);
+    neutrinoPath.elf[0] = '\0';
+    neutrinoPath.cwd[0] = '\0';
+    neutrinoVmc0[0] = '\0';
+    neutrinoVmc1[0] = '\0';
 
-                fd = open(vmc_path, O_RDONLY);
-                if (fd >= 0) {
-                    iop_fd = ps2sdk_get_iop_fd(fd);
-                    if (fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) == 0 && (startCluster = (unsigned int)fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
-
-                        // VMC only supports 32bit LBAs at the moment, so if the starting LBA + size of the VMC crosses the 32bit boundary
-                        // just report the VMC as being fragmented to prevent file system corruption.
-                        int vmcSectorCount = vmcSizeInMb * ((1024 * 1024) / 512); // size in MB * sectors per MB
-                        if (startingLBA + vmcSectorCount > 0x100000000) {
-                            LOG("BDMSUPPORT VMC bad LBA range\n");
-                            have_error = 2;
-                        }
-                        // Check VMC cluster chain for fragmentation (write operation can cause damage to the filesystem).
-                        else if (fileXioIoctl(iop_fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
-                            LOG("BDMSUPPORT Cluster Chain OK\n");
-                            have_error = 0;
-                            bdm_vmc_infos.active = 1;
-                            bdm_vmc_infos.start_sector = (u32)startingLBA;
-                            LOG("BDMSUPPORT VMC slot %d start: 0x%X\n", vmc_id, (u32)startingLBA);
-                        } else {
-                            LOG("BDMSUPPORT Cluster Chain NG\n");
-                            have_error = 2;
-                        }
-                    }
-
-                    close(fd);
-                }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
+            guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
+            selectedCore = CORE_LOADER_WOPL;
+        } else {
+            if (!sbFindNeutrino(&neutrinoPath, pDeviceData->bdmPrefix)) {
+                guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
+                selectedCore = CORE_LOADER_WOPL;
             }
         }
+    }
 
-        if (gAutoLaunchBDMGame == NULL) {
-            if (have_error) {
-                char error[256];
-                if (have_error == 2) // VMC file is fragmented
-                    snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name, (vmc_id + 1));
-                else
-                    snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name, (vmc_id + 1));
-                if (!guiMsgBox(error, 1, NULL)) {
-                    return;
+    int size_mcemu_irx = 0;
+
+    if (selectedCore == CORE_LOADER_WOPL) {
+        char vmc_name[32], vmc_path[256], have_error = 0;
+        int vmc_id;
+        bdm_vmc_infos_t bdm_vmc_infos;
+        vmc_superblock_t vmc_superblock;
+
+        for (vmc_id = 0; vmc_id < 2; vmc_id++) {
+            memset(&bdm_vmc_infos, 0, sizeof(bdm_vmc_infos_t));
+            strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
+            vmc_name[sizeof(vmc_name) - 1] = '\0';
+            if (vmc_name[0]) {
+                have_error = 1;
+                int vmcSizeInMb = sysCheckVMC(pDeviceData->bdmPrefix, "/", vmc_name, 0, &vmc_superblock);
+                if (vmcSizeInMb > 0) {
+                    bdm_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
+                    bdm_vmc_infos.flags |= 0x100;
+                    bdm_vmc_infos.specs.page_size = vmc_superblock.page_size;
+                    bdm_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
+                    bdm_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+
+                    sprintf(vmc_path, "%sVMC/%s.bin", pDeviceData->bdmPrefix, vmc_name);
+
+                    fd = open(vmc_path, O_RDONLY);
+                    if (fd >= 0) {
+                        iop_fd = ps2sdk_get_iop_fd(fd);
+                        if (fileXioIoctl2(iop_fd, USBMASS_IOCTL_GET_LBA, NULL, 0, &startingLBA, sizeof(startingLBA)) == 0 && (startCluster = (unsigned int)fileXioIoctl(iop_fd, USBMASS_IOCTL_GET_CLUSTER, vmc_path)) != 0) {
+
+                            // VMC only supports 32bit LBAs at the moment, so if the starting LBA + size of the VMC crosses the 32bit boundary
+                            // just report the VMC as being fragmented to prevent file system corruption.
+                            int vmcSectorCount = vmcSizeInMb * ((1024 * 1024) / 512); // size in MB * sectors per MB
+                            if (startingLBA + vmcSectorCount > 0x100000000) {
+                                LOG("BDMSUPPORT VMC bad LBA range\n");
+                                have_error = 2;
+                            }
+                            // Check VMC cluster chain for fragmentation (write operation can cause damage to the filesystem).
+                            else if (fileXioIoctl(iop_fd, USBMASS_IOCTL_CHECK_CHAIN, "") == 1) {
+                                LOG("BDMSUPPORT Cluster Chain OK\n");
+                                have_error = 0;
+                                bdm_vmc_infos.active = 1;
+                                bdm_vmc_infos.start_sector = (u32)startingLBA;
+                                LOG("BDMSUPPORT VMC slot %d start: 0x%X\n", vmc_id, (u32)startingLBA);
+                            } else {
+                                LOG("BDMSUPPORT Cluster Chain NG\n");
+                                have_error = 2;
+                            }
+                        }
+
+                        close(fd);
+                    }
                 }
             }
-        } else
-            LOG("VMC error\n");
 
-        for (i = 0; i < size_bdm_mcemu_irx; i++) {
-            if (((u32 *)&bdm_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
-                if (bdm_vmc_infos.active)
-                    size_mcemu_irx = size_bdm_mcemu_irx;
-                memcpy(&((u32 *)&bdm_mcemu_irx)[i], &bdm_vmc_infos, sizeof(bdm_vmc_infos_t));
-                break;
+            if (gAutoLaunchBDMGame == NULL) {
+                if (have_error) {
+                    char error[256];
+                    if (have_error == 2) // VMC file is fragmented
+                        snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name, (vmc_id + 1));
+                    else
+                        snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name, (vmc_id + 1));
+                    if (!guiMsgBox(error, 1, NULL)) {
+                        return;
+                    }
+                }
+            } else
+                LOG("VMC error\n");
+
+            for (i = 0; i < size_bdm_mcemu_irx; i++) {
+                if (((u32 *)&bdm_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
+                    if (bdm_vmc_infos.active)
+                        size_mcemu_irx = size_bdm_mcemu_irx;
+                    memcpy(&((u32 *)&bdm_mcemu_irx)[i], &bdm_vmc_infos, sizeof(bdm_vmc_infos_t));
+                    break;
+                }
             }
         }
     }
@@ -617,26 +644,31 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         settings->hddIsLBA48 = pDeviceData->bdmHddIsLBA48;
     }
 
-    int coreLoader = 0;
-    coreLoader = pgcfg->core_loader;
-
-    const char *neutrinoPath = NULL;
-    if (coreLoader) {
-        neutrinoPath = sbFileExists(NEUTRINO_PATH) ? NEUTRINO_PATH : (sbFileExists(NEUTRINO_ALT_PATH) ? NEUTRINO_ALT_PATH : NULL);
-
-        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
-            guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
-            coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
-            guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
-            coreLoader = 0;
-        }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sbCreateNeutrinoVMCPath(neutrinoVmc0, sizeof(neutrinoVmc0), pDeviceData->bdmPrefix, pgcfg->vmc1);
+        sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), pDeviceData->bdmPrefix, pgcfg->vmc2);
     }
 
-    sbMMCESendGameId(game->startup);
+    if (!(selectedCore == CORE_LOADER_NEUTRINO && sbPathIsMC(neutrinoPath.elf)))
+        sbMMCESendGameId(game->startup);
+
+    int deinitException = NO_EXCEPTION;
+    int deinitMode = itemList->mode;
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        int elfDevice = -1;
+        int elfMode = sbGetPathModeAndDevice(neutrinoPath.elf, &elfDevice);
+
+        if (elfMode >= 0) {
+            deinitException = UNMOUNT_EXCEPTION;
+            deinitMode = elfMode;
+        }
+
+        LOG("NEUTRINO ELF MODE=%d DEVICE=%d\n", elfMode, elfDevice);
+    }
 
     if (gAutoLaunchBDMGame == NULL)
-        deinit(NO_EXCEPTION, itemList->mode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
+        deinit(deinitException, deinitMode); // CAREFUL: deinit will call bdmCleanUp, so bdmGames/game will be freed
     else {
         miniDeinit();
 
@@ -649,8 +681,8 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
 
     LOG("bdm pre sysLaunchLoaderElf\n");
 
-    if (coreLoader) {
-        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoPath);
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -967,11 +967,20 @@ void guiGameSavePadMacroGlobalConfig(void)
 }
 #endif
 
+static int guiGameNormaliseCoreLoader(int value)
+{
+    return value == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
+}
+
 void guiGameShowCompatConfig(int id, item_list_t *support)
 {
     int i;
 
-    const char *loaders[] = {"<OPL>", "Neutrino", NULL};
+    const char *loaders[] = {
+        [CORE_LOADER_WOPL] = "<wOPL>",
+        [CORE_LOADER_NEUTRINO] = "Neutrino",
+        NULL};
+
     diaSetEnum(diaCompatConfig, COMPAT_LOADER, loaders);
 
     if (support->flags & MODE_FLAG_COMPAT_DMA) {
@@ -999,6 +1008,8 @@ void guiGameShowCompatConfig(int id, item_list_t *support)
         }
 
         diaGetInt(diaCompatConfig, COMPAT_LOADER, &coreLoader);
+        coreLoader = guiGameNormaliseCoreLoader(coreLoader);
+
         diaGetInt(diaCompatConfig, COMPAT_DMA, &dmaMode);
         diaGetString(diaCompatConfig, COMPAT_GAMEID, hexid, sizeof(hexid));
         diaGetString(diaCompatConfig, COMPAT_ALTSTARTUP, altStartup, sizeof(altStartup));
@@ -1022,6 +1033,7 @@ int guiGameSaveConfig(per_game_cfg_t *pg, item_list_t *support)
     }
 
     diaGetInt(diaCompatConfig, COMPAT_LOADER, &coreLoader);
+    coreLoader = guiGameNormaliseCoreLoader(coreLoader);
     pg->core_loader = coreLoader;
 
 #ifdef GSM
@@ -1344,7 +1356,7 @@ void guiGameLoadConfig(item_list_t *support, per_game_cfg_t *pg)
     for (int i = 0; i < COMPAT_MODE_COUNT; ++i)
         diaSetInt(diaCompatConfig, COMPAT_MODE_BASE + i, (compatMode & (1 << i)) ? 1 : 0);
 
-    coreLoader = pg ? pg->core_loader : 0;
+    coreLoader = pg ? guiGameNormaliseCoreLoader(pg->core_loader) : CORE_LOADER_WOPL;
     diaSetInt(diaCompatConfig, COMPAT_LOADER, coreLoader);
 
 #ifdef GSM

--- a/src/hddsupport.c
+++ b/src/hddsupport.c
@@ -947,89 +947,23 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     else
         game = gAutoLaunchGame;
 
-    apa_sub_t parts[APA_MAXSUB + 1];
-    char vmc_name[2][32];
-    int part_valid = 0, size_mcemu_irx = 0, nparts;
-    hdd_vmc_infos_t hdd_vmc_infos;
-    memset(&hdd_vmc_infos, 0, sizeof(hdd_vmc_infos_t));
+    int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
+    int isZSO = 0;
+    int size_mcemu_irx = 0;
 
-    strncpy(vmc_name[0], pgcfg->vmc1, sizeof(vmc_name[0]) - 1);
-    vmc_name[0][sizeof(vmc_name[0]) - 1] = '\0';
+    neutrino_path_t neutrinoPath;
+    char neutrinoVmc0[256];
+    char neutrinoVmc1[256];
 
-    strncpy(vmc_name[1], pgcfg->vmc2, sizeof(vmc_name[1]) - 1);
-    vmc_name[1][sizeof(vmc_name[1]) - 1] = '\0';
+    neutrinoPath.elf[0] = '\0';
+    neutrinoPath.cwd[0] = '\0';
+    neutrinoVmc0[0] = '\0';
+    neutrinoVmc1[0] = '\0';
 
-    if (vmc_name[0][0] || vmc_name[1][0]) {
-        nparts = hddGetPartitionInfo(gOPLPart, parts);
-        if (nparts > 0 && nparts <= 5) {
-            for (i = 0; i < nparts; i++) {
-                hdd_vmc_infos.parts[i].start = parts[i].start;
-                hdd_vmc_infos.parts[i].length = parts[i].length;
-                LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].start : 0x%X\n", i, hdd_vmc_infos.parts[i].start);
-                LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].length : 0x%X\n", i, hdd_vmc_infos.parts[i].length);
-            }
-            part_valid = 1;
-        }
-    }
-
-    if (part_valid) {
-        char vmc_path[256];
-        int vmc_id, have_error = 0;
-        vmc_superblock_t vmc_superblock;
-        pfs_blockinfo_t blocks[11];
-
-        for (vmc_id = 0; vmc_id < 2; vmc_id++) {
-            if (vmc_name[vmc_id][0]) {
-                have_error = 1;
-                hdd_vmc_infos.active = 0;
-                if (sysCheckVMC(gHDDPrefix, "/", vmc_name[vmc_id], 0, &vmc_superblock) > 0) {
-                    hdd_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
-                    hdd_vmc_infos.flags |= 0x100;
-                    hdd_vmc_infos.specs.page_size = vmc_superblock.page_size;
-                    hdd_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
-                    hdd_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
-
-                    // Check vmc inode block chain (write operation can cause damage)
-                    snprintf(vmc_path, sizeof(vmc_path), "%sVMC/%s.bin", gHDDPrefix, vmc_name[vmc_id]);
-                    if ((nparts = hddGetFileBlockInfo(vmc_path, parts, blocks, 11)) > 0) {
-                        have_error = 0;
-                        hdd_vmc_infos.active = 1;
-                        for (i = 0; i < nparts - 1; i++) {
-                            hdd_vmc_infos.blocks[i].number = blocks[i + 1].number;
-                            hdd_vmc_infos.blocks[i].subpart = blocks[i + 1].subpart;
-                            hdd_vmc_infos.blocks[i].count = blocks[i + 1].count;
-                            LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].number     : 0x%X\n", i, hdd_vmc_infos.blocks[i].number);
-                            LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].subpart    : 0x%X\n", i, hdd_vmc_infos.blocks[i].subpart);
-                            LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].count      : 0x%X\n", i, hdd_vmc_infos.blocks[i].count);
-                        }
-                    } else { // else VMC file is too fragmented
-                        LOG("HDDSUPPORT Block Chain NG\n");
-                        have_error = 2;
-                    }
-                }
-
-                if (have_error) {
-                    if (gAutoLaunchGame == NULL) {
-                        char error[256];
-                        if (have_error == 2) // VMC file is fragmented
-                            snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
-                        else
-                            snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
-                        if (!guiMsgBox(error, 1, NULL))
-                            return;
-                    } else
-                        LOG("VMC error\n");
-                }
-
-                for (i = 0; i < size_hdd_mcemu_irx; i++) {
-                    if (((u32 *)&hdd_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
-                        if (hdd_vmc_infos.active)
-                            size_mcemu_irx = size_hdd_mcemu_irx;
-                        memcpy(&((u32 *)&hdd_mcemu_irx)[i], &hdd_vmc_infos, sizeof(hdd_vmc_infos_t));
-                        break;
-                    }
-                }
-            }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        if (!sbFindNeutrino(&neutrinoPath, gOPLPart)) {
+            guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
+            selectedCore = CORE_LOADER_WOPL;
         }
     }
 
@@ -1103,10 +1037,6 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     if (gPS2Logo)
         EnablePS2Logo = CheckPS2Logo(0, game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET);
 
-    int coreLoader = 0;
-    int isZSO = 0;
-    coreLoader = pgcfg->core_loader;
-
     // Check for ZSO to correctly adjust layer1 start
     settings->common.layer1_start = 0; // cdvdman will read it from APA header
     hddReadSectors(game->start_sector + OPL_HDD_MODE_PS2LOGO_OFFSET, 1, IOBuffer);
@@ -1122,23 +1052,129 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         isZSO = 1;
     }
 
-    const char *neutrinoPath = NULL;
-    if (coreLoader) {
-        neutrinoPath = sbFileExists(NEUTRINO_PATH) ? NEUTRINO_PATH : (sbFileExists(NEUTRINO_ALT_PATH) ? NEUTRINO_ALT_PATH : NULL);
+    if (selectedCore == CORE_LOADER_NEUTRINO && isZSO) {
+        guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
+        selectedCore = CORE_LOADER_WOPL;
+    }
 
-        if (isZSO) {
-            guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
-            coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
-            guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
-            coreLoader = 0;
+    if (selectedCore == CORE_LOADER_WOPL) {
+        apa_sub_t parts[APA_MAXSUB + 1];
+        char vmc_name[2][32];
+        int part_valid = 0, nparts;
+        hdd_vmc_infos_t hdd_vmc_infos;
+        memset(&hdd_vmc_infos, 0, sizeof(hdd_vmc_infos_t));
+
+        strncpy(vmc_name[0], pgcfg->vmc1, sizeof(vmc_name[0]) - 1);
+        vmc_name[0][sizeof(vmc_name[0]) - 1] = '\0';
+
+        strncpy(vmc_name[1], pgcfg->vmc2, sizeof(vmc_name[1]) - 1);
+        vmc_name[1][sizeof(vmc_name[1]) - 1] = '\0';
+
+        if (vmc_name[0][0] || vmc_name[1][0]) {
+            nparts = hddGetPartitionInfo(gOPLPart, parts);
+            if (nparts > 0 && nparts <= 5) {
+                for (i = 0; i < nparts; i++) {
+                    hdd_vmc_infos.parts[i].start = parts[i].start;
+                    hdd_vmc_infos.parts[i].length = parts[i].length;
+                    LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].start : 0x%X\n", i, hdd_vmc_infos.parts[i].start);
+                    LOG("HDDSUPPORT hdd_vmc_infos.parts[%d].length : 0x%X\n", i, hdd_vmc_infos.parts[i].length);
+                }
+                part_valid = 1;
+            }
+        }
+
+        if (part_valid) {
+            char vmc_path[256];
+            int vmc_id;
+            vmc_superblock_t vmc_superblock;
+            pfs_blockinfo_t blocks[11];
+
+            for (vmc_id = 0; vmc_id < 2; vmc_id++) {
+                int have_error = 0;
+
+                if (vmc_name[vmc_id][0]) {
+                    have_error = 1;
+                    hdd_vmc_infos.active = 0;
+                    if (sysCheckVMC(gHDDPrefix, "/", vmc_name[vmc_id], 0, &vmc_superblock) > 0) {
+                        hdd_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
+                        hdd_vmc_infos.flags |= 0x100;
+                        hdd_vmc_infos.specs.page_size = vmc_superblock.page_size;
+                        hdd_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
+                        hdd_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+
+                        // Check vmc inode block chain (write operation can cause damage)
+                        snprintf(vmc_path, sizeof(vmc_path), "%sVMC/%s.bin", gHDDPrefix, vmc_name[vmc_id]);
+                        if ((nparts = hddGetFileBlockInfo(vmc_path, parts, blocks, 11)) > 0) {
+                            have_error = 0;
+                            hdd_vmc_infos.active = 1;
+                            for (i = 0; i < nparts - 1; i++) {
+                                hdd_vmc_infos.blocks[i].number = blocks[i + 1].number;
+                                hdd_vmc_infos.blocks[i].subpart = blocks[i + 1].subpart;
+                                hdd_vmc_infos.blocks[i].count = blocks[i + 1].count;
+                                LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].number     : 0x%X\n", i, hdd_vmc_infos.blocks[i].number);
+                                LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].subpart    : 0x%X\n", i, hdd_vmc_infos.blocks[i].subpart);
+                                LOG("HDDSUPPORT hdd_vmc_infos.blocks[%d].count      : 0x%X\n", i, hdd_vmc_infos.blocks[i].count);
+                            }
+                        } else { // else VMC file is too fragmented
+                            LOG("HDDSUPPORT Block Chain NG\n");
+                            have_error = 2;
+                        }
+                    }
+
+                    if (have_error) {
+                        if (gAutoLaunchGame == NULL) {
+                            char error[256];
+                            if (have_error == 2) // VMC file is fragmented
+                                snprintf(error, sizeof(error), _l(_STR_ERR_VMC_FRAGMENTED_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
+                            else
+                                snprintf(error, sizeof(error), _l(_STR_ERR_VMC_CONTINUE), vmc_name[vmc_id], (vmc_id + 1));
+                            if (!guiMsgBox(error, 1, NULL))
+                                return;
+                        } else
+                            LOG("VMC error\n");
+                    }
+
+                    for (i = 0; i < size_hdd_mcemu_irx; i++) {
+                        if (((u32 *)&hdd_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
+                            if (hdd_vmc_infos.active)
+                                size_mcemu_irx = size_hdd_mcemu_irx;
+                            memcpy(&((u32 *)&hdd_mcemu_irx)[i], &hdd_vmc_infos, sizeof(hdd_vmc_infos_t));
+                            break;
+                        }
+                    }
+                }
+            }
         }
     }
 
-    sbMMCESendGameId(game->startup);
+    char partitionName[APA_IDMAX + 1];
+    snprintf(partitionName, sizeof(partitionName), "%s", game->partition_name);
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sbCreateNeutrinoVMCPath(neutrinoVmc0, sizeof(neutrinoVmc0), gOPLPart, pgcfg->vmc1);
+        sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), gOPLPart, pgcfg->vmc2);
+    }
+
+    if (!(selectedCore == CORE_LOADER_NEUTRINO && sbPathIsMC(neutrinoPath.elf)))
+        sbMMCESendGameId(game->startup);
+
+    int deinitException = NO_EXCEPTION;
+    int deinitMode = HDD_MODE;
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        int elfDevice = -1;
+        int elfMode = sbGetPathModeAndDevice(neutrinoPath.elf, &elfDevice);
+
+        if (elfMode >= 0) {
+            deinitException = UNMOUNT_EXCEPTION;
+            deinitMode = elfMode;
+        }
+
+        LOG("NEUTRINO ELF MODE=%d DEVICE=%d\n", elfMode, elfDevice);
+    }
 
     if (gAutoLaunchGame == NULL)
-        deinit(NO_EXCEPTION, HDD_MODE); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
+        deinit(deinitException, deinitMode); // CAREFUL: deinit will call hddCleanUp, so hddGames/game will be freed
     else {
         miniDeinit();
 
@@ -1149,9 +1185,9 @@ void hddLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         fileXioDevctl("pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
     }
 
-    if (coreLoader) {
-        LOG("partition_name=[%s] name=[%s] startup=[%s]\n", game->partition_name, game->name, game->startup);
-        sysLaunchNeutrino("apa", game->partition_name, compatMode, EnablePS2Logo, neutrinoPath);
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        LOG("partition_name=[%s]\n", partitionName);
+        sysLaunchNeutrino("apa", partitionName, compatMode, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -101,18 +101,23 @@ void mmceInit(item_list_t *itemList)
     mmceGameList.enabled = 1;
 }
 
-void mmceSendGameId(const char *gameId)
+void mmceSendGameIdToDevice(int device, const char *gameId)
 {
+    char dev[16];
+
     if (!gameId || !gameId[0])
         return;
 
-    // probe and set device
-    const char *dev = NULL;
-    if (fileXioDevctl("mmce0:/", 0x1, NULL, 0, NULL, 0) != -1)
-        dev = "mmce0:/";
-    else if (fileXioDevctl("mmce1:/", 0x1, NULL, 0, NULL, 0) != -1)
-        dev = "mmce1:/";
-    else
+    if (device != 0 && device != 1) {
+        if (!strncmp(mmcePrefix, "mmce1:", 6))
+            device = 1;
+        else
+            device = 0;
+    }
+
+    snprintf(dev, sizeof(dev), "mmce%d:/", device);
+
+    if (fileXioDevctl(dev, 0x1, NULL, 0, NULL, 0) < 0)
         return;
 
     // small delay to let config write before sending game id (remember last game)
@@ -133,6 +138,11 @@ void mmceSendGameId(const char *gameId)
         if ((status & 1) == 0)
             return; // ready
     }
+}
+
+void mmceSendGameId(const char *gameId)
+{
+    mmceSendGameIdToDevice(-1, gameId);
 }
 
 item_list_t *mmceGetObject(int initOnly)
@@ -261,11 +271,36 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     u32 layer1_start, layer1_offset;
     unsigned short int layer1_part;
 
-    // No Autolaunch yet
-    if (gAutoLaunchBDMGame == NULL)
+    /* No Autolaunch yet
+    if (gAutoLaunchMMCEGame == NULL)
         game = &mmceGames[id];
     else
-        game = gAutoLaunchBDMGame;
+        game = gAutoLaunchMMCEGame;*/
+
+    game = &mmceGames[id];
+
+    int selectedCore = pgcfg->core_loader == CORE_LOADER_NEUTRINO ? CORE_LOADER_NEUTRINO : CORE_LOADER_WOPL;
+
+    neutrino_path_t neutrinoPath;
+    char neutrinoVmc0[256];
+    char neutrinoVmc1[256];
+
+    neutrinoPath.elf[0] = '\0';
+    neutrinoPath.cwd[0] = '\0';
+    neutrinoVmc0[0] = '\0';
+    neutrinoVmc1[0] = '\0';
+
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
+            guiWarning("Neutrino does not support this file format, launching with <wOPL> core", 6);
+            selectedCore = CORE_LOADER_WOPL;
+        } else {
+            if (!sbFindNeutrino(&neutrinoPath, mmcePrefix)) {
+                guiWarning("Neutrino ELF not found, launching with <wOPL> core", 6);
+                selectedCore = CORE_LOADER_WOPL;
+            }
+        }
+    }
 
     void *irx = &mmce_cdvdman_irx;
     int irx_size = size_mmce_cdvdman_irx;
@@ -274,43 +309,47 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     if (settings == NULL)
         return;
 
-    char vmc_name[32];
-    char vmc_path[256];
-    int vmc_size_mb;
-    int vmc_id, size_mcemu_irx = 0;
-    int vmc_fd;
-    mmce_vmc_infos_t mmce_vmc_infos;
-    vmc_superblock_t vmc_superblock;
+    int size_mcemu_irx = 0;
 
-    for (vmc_id = 0; vmc_id < 2; vmc_id++) {
-        memset(&mmce_vmc_infos, 0, sizeof(mmce_vmc_infos));
-        strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
-        vmc_name[sizeof(vmc_name) - 1] = '\0';
-        if (vmc_name[0]) {
-            vmc_size_mb = sysCheckVMC(mmcePrefix, "/", vmc_name, 0, &vmc_superblock);
-            if (vmc_size_mb > 0) {
-                mmce_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
-                mmce_vmc_infos.flags |= 0x100;
-                mmce_vmc_infos.specs.page_size = vmc_superblock.page_size;
-                mmce_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
-                mmce_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
+    if (selectedCore == CORE_LOADER_WOPL) {
+        char vmc_name[32];
+        char vmc_path[256];
+        int vmc_size_mb;
+        int vmc_id;
+        int vmc_fd;
+        mmce_vmc_infos_t mmce_vmc_infos;
+        vmc_superblock_t vmc_superblock;
 
-                sprintf(vmc_path, "%sVMC/%s.bin", mmcePrefix, vmc_name);
+        for (vmc_id = 0; vmc_id < 2; vmc_id++) {
+            memset(&mmce_vmc_infos, 0, sizeof(mmce_vmc_infos));
+            strncpy(vmc_name, vmc_id == 0 ? pgcfg->vmc1 : pgcfg->vmc2, sizeof(vmc_name) - 1);
+            vmc_name[sizeof(vmc_name) - 1] = '\0';
+            if (vmc_name[0]) {
+                vmc_size_mb = sysCheckVMC(mmcePrefix, "/", vmc_name, 0, &vmc_superblock);
+                if (vmc_size_mb > 0) {
+                    mmce_vmc_infos.flags = vmc_superblock.mc_flag & 0xFF;
+                    mmce_vmc_infos.flags |= 0x100;
+                    mmce_vmc_infos.specs.page_size = vmc_superblock.page_size;
+                    mmce_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
+                    mmce_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
 
-                vmc_fd = fileXioOpen(vmc_path, 0x3, 0666);
-                if (vmc_fd >= 0) {
-                    mmce_vmc_infos.fd = fileXioIoctl2(vmc_fd, 0x80, NULL, 0, NULL, 0);
-                    mmce_vmc_infos.active = 1;
+                    sprintf(vmc_path, "%sVMC/%s.bin", mmcePrefix, vmc_name);
+
+                    vmc_fd = fileXioOpen(vmc_path, 0x3, 0666);
+                    if (vmc_fd >= 0) {
+                        mmce_vmc_infos.fd = fileXioIoctl2(vmc_fd, 0x80, NULL, 0, NULL, 0);
+                        mmce_vmc_infos.active = 1;
+                    }
                 }
             }
-        }
 
-        for (i = 0; i < size_mmce_mcemu_irx; i++) {
-            if (((u32 *)&mmce_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
-                if (mmce_vmc_infos.active)
-                    size_mcemu_irx = size_mmce_mcemu_irx;
-                memcpy(&((u32 *)&mmce_mcemu_irx)[i], &mmce_vmc_infos, sizeof(mmce_vmc_infos_t));
-                break;
+            for (i = 0; i < size_mmce_mcemu_irx; i++) {
+                if (((u32 *)&mmce_mcemu_irx)[i] == (0xC0DEFAC0 + vmc_id)) {
+                    if (mmce_vmc_infos.active)
+                        size_mcemu_irx = size_mmce_mcemu_irx;
+                    memcpy(&((u32 *)&mmce_mcemu_irx)[i], &mmce_vmc_infos, sizeof(mmce_vmc_infos_t));
+                    break;
+                }
             }
         }
     }
@@ -405,43 +444,50 @@ void mmceLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     LOG("name: %s\n", game->name);
     LOG("start: %s\n", game->startup);
 
-    int coreLoader = 0;
-    coreLoader = pgcfg->core_loader;
-
-    const char *neutrinoPath = NULL;
-    if (coreLoader) {
-        neutrinoPath = sbFileExists(NEUTRINO_PATH) ? NEUTRINO_PATH : (sbFileExists(NEUTRINO_ALT_PATH) ? NEUTRINO_ALT_PATH : NULL);
-
-        if (game->format == GAME_FORMAT_USBLD || !strcasecmp(game->extension, ".zso")) {
-            guiWarning("Neutrino does not support this file format, launching with <OPL> core", 6);
-            coreLoader = 0;
-        } else if (neutrinoPath == NULL) {
-            guiWarning("Neutrino ELF not found, launching with <OPL> core", 6);
-            coreLoader = 0;
-        }
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sbCreateNeutrinoVMCPath(neutrinoVmc0, sizeof(neutrinoVmc0), mmcePrefix, pgcfg->vmc1);
+        sbCreateNeutrinoVMCPath(neutrinoVmc1, sizeof(neutrinoVmc1), mmcePrefix, pgcfg->vmc2);
     }
 
     // mcReset();
     // mcInit(MC_TYPE_XMC);
 
-    mmceSendGameId(game->startup);
+    int gameDevice = -1;
+    int elfDevice = -1;
+    int elfMode = -1;
 
-    if (gAutoLaunchBDMGame == NULL)
-        deinit(NO_EXCEPTION, MMCE_MODE); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
+    sbGetPathModeAndDevice(partname, &gameDevice);
+
+    if (selectedCore == CORE_LOADER_NEUTRINO)
+        elfMode = sbGetPathModeAndDevice(neutrinoPath.elf, &elfDevice);
+
+    if (!(selectedCore == CORE_LOADER_NEUTRINO && sbPathIsMC(neutrinoPath.elf)))
+        mmceSendGameIdToDevice(gameDevice, game->startup);
+
+    int deinitException = NO_EXCEPTION;
+    int deinitMode = MMCE_MODE;
+
+    if (selectedCore == CORE_LOADER_NEUTRINO && elfMode >= 0) {
+        deinitException = UNMOUNT_EXCEPTION;
+        deinitMode = elfMode;
+    }
+
+    deinit(deinitException, deinitMode); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
 
     /* No autolaunch yet
+    if (gAutoLaunchMMCEGame == NULL)
+        deinit(deinitException, deinitMode); // CAREFUL: deinit will call mmceCleanUp, so mmceGames/game will be freed
     else {
         miniDeinit();
 
-        free(gAutoLaunchBDMGame);
-        gAutoLaunchBDMGame = NULL;
+        free(gAutoLaunchMMCEGame);
+        gAutoLaunchMMCEGame = NULL;
     }*/
 
-    if (coreLoader) {
-        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoPath);
+    if (selectedCore == CORE_LOADER_NEUTRINO) {
+        sysLaunchNeutrino("mmce", partname, compatmask, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
-
 
     settings->common.zso_cache = 0;
 

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -1,4 +1,3 @@
-
 #include "include/common.h"
 #include "include/lang.h"
 #include "include/util.h"
@@ -1389,3 +1388,266 @@ int sbLoadImage(const char *path, const char *file)
     return result;
 }
 #endif
+
+static int sbTryNeutrinoPath(neutrino_path_t *path, const char *cwd)
+{
+    int i;
+    int length;
+    const char *elfNames[] = {
+        "neutrino.elf",
+        "neutrino.ELF",
+        "NEUTRINO.elf",
+        "NEUTRINO.ELF",
+    };
+
+    if (!path || !cwd || !cwd[0])
+        return 0;
+
+    snprintf(path->cwd, sizeof(path->cwd), "%s", cwd);
+
+    length = strlen(path->cwd);
+    if (length <= 0 || length >= sizeof(path->cwd) - 1)
+        return 0;
+
+    if (path->cwd[length - 1] != '/') {
+        path->cwd[length++] = '/';
+        path->cwd[length] = '\0';
+    }
+
+    for (i = 0; i < (int)(sizeof(elfNames) / sizeof(elfNames[0])); i++) {
+        snprintf(path->elf, sizeof(path->elf), "%s%s", path->cwd, elfNames[i]);
+        LOG("SUPPORTBASE: Checking Neutrino ELF '%s'\n", path->elf);
+
+        if (sbFileExists(path->elf)) {
+            LOG("SUPPORTBASE: Neutrino ELF found at '%s'\n", path->elf);
+            return 1;
+        }
+    }
+
+    path->elf[0] = '\0';
+    path->cwd[0] = '\0';
+
+    return 0;
+}
+
+/*
+ * HDD path must not use pfs0: because hddLaunchGame() deinitializes/unmounts it before launching Neutrino
+ * For +wOPL: hdd0:+wOPL/neutrino/neutrino.elf
+ * For __common: hdd0:__common/wOPL/neutrino/neutrino.elf
+ */
+int sbFindNeutrino(neutrino_path_t *path, const char *preferredPrefix)
+{
+    int i;
+    char cwd[256];
+    const char *mcPaths[] = {
+        "mc0:NEUTRINO",
+        "mc1:NEUTRINO",
+        "mc0:/NEUTRINO",
+        "mc1:/NEUTRINO",
+        "mc0:neutrino",
+        "mc1:neutrino",
+        "mc0:/neutrino",
+        "mc1:/neutrino",
+        "mc0:/APPS/neutrino",
+        "mc1:/APPS/neutrino",
+        "mc0:/APPS/NEUTRINO",
+        "mc1:/APPS/NEUTRINO",
+    };
+
+    if (!path)
+        return 0;
+
+    path->elf[0] = '\0';
+    path->cwd[0] = '\0';
+
+    if (preferredPrefix && preferredPrefix[0]) {
+        if (!strncmp(preferredPrefix, "hdd0:", 5)) {
+            if (preferredPrefix[5] != '+') {
+                snprintf(cwd, sizeof(cwd), "%s/%s/neutrino", preferredPrefix, WOPL_CONFIG_NAME);
+                if (sbTryNeutrinoPath(path, cwd))
+                    return 1;
+
+                snprintf(cwd, sizeof(cwd), "%s/%s/NEUTRINO", preferredPrefix, WOPL_CONFIG_NAME);
+                if (sbTryNeutrinoPath(path, cwd))
+                    return 1;
+            }
+
+            snprintf(cwd, sizeof(cwd), "%s/neutrino", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return 1;
+
+            snprintf(cwd, sizeof(cwd), "%s/NEUTRINO", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return 1;
+        } else {
+            snprintf(cwd, sizeof(cwd), "%sneutrino", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return 1;
+
+            snprintf(cwd, sizeof(cwd), "%sNEUTRINO", preferredPrefix);
+            if (sbTryNeutrinoPath(path, cwd))
+                return 1;
+        }
+    }
+
+    for (i = 0; i < MAX_BDM_DEVICES; i++) {
+        snprintf(cwd, sizeof(cwd), "mass%d:/neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+
+        snprintf(cwd, sizeof(cwd), "mass%d:neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+
+        snprintf(cwd, sizeof(cwd), "mass%d:/NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+
+        snprintf(cwd, sizeof(cwd), "mass%d:NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+    }
+
+    for (i = 0; i < 2; i++) {
+        snprintf(cwd, sizeof(cwd), "mmce%d:/neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+
+        snprintf(cwd, sizeof(cwd), "mmce%d:neutrino", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+
+        snprintf(cwd, sizeof(cwd), "mmce%d:/NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+
+        snprintf(cwd, sizeof(cwd), "mmce%d:NEUTRINO", i);
+        if (sbTryNeutrinoPath(path, cwd))
+            return 1;
+    }
+
+    for (i = 0; i < (int)(sizeof(mcPaths) / sizeof(mcPaths[0])); i++) {
+        if (sbTryNeutrinoPath(path, mcPaths[i]))
+            return 1;
+    }
+
+    return 0;
+}
+
+void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const char *vmc)
+{
+    if (!path || length <= 0)
+        return;
+
+    path[0] = '\0';
+
+    if (!prefix || !prefix[0] || !vmc || !vmc[0])
+        return;
+
+    if (!strncmp(prefix, "hdd0:", 5)) {
+        if (prefix[5] != '+')
+            snprintf(path, length, "%s/%s/VMC/%s.bin", prefix, WOPL_CONFIG_NAME, vmc);
+        else
+            snprintf(path, length, "%s/VMC/%s.bin", prefix, vmc);
+    } else
+        snprintf(path, length, "%sVMC/%s.bin", prefix, vmc);
+}
+
+static int sbParsePathDeviceIndex(const char *path, const char *prefix, int *device)
+{
+    const char *p;
+    int dev = 0;
+    int haveDigit = 0;
+    int prefixLen = strlen(prefix);
+
+    if (!path || strncmp(path, prefix, prefixLen))
+        return 0;
+
+    p = path + prefixLen;
+
+    while (*p >= '0' && *p <= '9') {
+        haveDigit = 1;
+        dev = dev * 10 + (*p - '0');
+        p++;
+    }
+
+    if (*p != ':')
+        return 0;
+
+    if (!haveDigit)
+        dev = 0;
+
+    if (device)
+        *device = dev;
+
+    return 1;
+}
+
+int sbGetPathModeAndDevice(const char *path, int *device)
+{
+    const char *blkdevnameend;
+    const char *prefixend;
+    int i, blkdevnamelen, prefixlen;
+    int dev;
+    item_list_t *listSupport;
+
+    if (device)
+        *device = -1;
+
+    if (!path || !path[0])
+        return -1;
+
+    if (!strncmp(path, "hdd0:", 5) || !strncmp(path, "pfs0:", 5))
+        return HDD_MODE;
+
+    if (sbParsePathDeviceIndex(path, "mass", &dev)) {
+        if (dev < 0 || dev >= MAX_BDM_DEVICES)
+            return -1;
+
+        if (device)
+            *device = dev;
+
+        return BDM_MODE + dev;
+    }
+
+    if (sbParsePathDeviceIndex(path, "mmce", &dev)) {
+        if (device)
+            *device = dev;
+
+        return MMCE_MODE;
+    }
+
+    blkdevnameend = strchr(path, ':');
+    if (blkdevnameend == NULL)
+        return -1;
+
+    blkdevnamelen = (int)(blkdevnameend - path);
+
+    for (i = 0; i < MODE_COUNT; i++) {
+        listSupport = list_support[i].support;
+        if ((listSupport != NULL) && (listSupport->itemGetPrefix != NULL)) {
+            char *prefix = listSupport->itemGetPrefix(listSupport);
+            if (prefix != NULL) {
+                prefixend = strchr(prefix, ':');
+                if (prefixend != NULL) {
+                    prefixlen = (int)(prefixend - prefix);
+
+                    if (blkdevnamelen == prefixlen && strncmp(path, prefix, blkdevnamelen) == 0)
+                        return listSupport->mode;
+                }
+            }
+        }
+    }
+
+    return -1;
+}
+
+int sbGetPathMode(const char *path)
+{
+    return sbGetPathModeAndDevice(path, NULL);
+}
+
+int sbPathIsMC(const char *path)
+{
+    return path && (!strncmp(path, "mc0:", 4) || !strncmp(path, "mc1:", 4));
+}

--- a/src/system.c
+++ b/src/system.c
@@ -66,6 +66,9 @@ typedef struct
 extern unsigned char eecore_elf[];
 extern unsigned int size_eecore_elf;
 
+extern unsigned char neutrino_loader_elf[];
+extern unsigned int size_neutrino_loader_elf;
+
 extern unsigned char IOPRP_img[];
 extern unsigned int size_IOPRP_img;
 
@@ -1163,10 +1166,10 @@ static const char *getDeviceName(const char *driver)
 {
     if (!strncmp(driver, "usb", 3))
         return "usb";
-    else if (!strncmp(driver, "sd", 2))
-        return "ilink";
     else if (!strncmp(driver, "sdc", 3))
         return "mx4sio";
+    else if (!strncmp(driver, "sd", 2))
+        return "ilink";
     else if (!strncmp(driver, "ata", 3))
         return "ata";
     else if (!strncmp(driver, "apa", 3))
@@ -1202,21 +1205,79 @@ static int convertCompatmaskToModes(int compatmask)
     return atoi(result);
 }
 
-void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath)
+static int LoadNeutrinoELF(const char *filename, int argc, char *argv[])
+{
+    u8 *boot_elf;
+    elf_header_t *eh;
+    elf_pheader_t *eph;
+    void *pdata;
+    char *execArgv[16];
+    int i;
+
+    if (!filename || !filename[0])
+        return -1;
+
+    if (argc + 2 > (int)(sizeof(execArgv) / sizeof(execArgv[0]))) {
+        LOG("NEUTRINO ERROR: too many args\n");
+        return -1;
+    }
+
+    execArgv[0] = "";
+    execArgv[1] = (char *)filename;
+
+    for (i = 0; i < argc; i++)
+        execArgv[i + 2] = argv[i];
+
+    boot_elf = (u8 *)&neutrino_loader_elf;
+    eh = (elf_header_t *)boot_elf;
+    if (*(u32 *)boot_elf != ELF_MAGIC) {
+        LOG("NEUTRINO ERROR: bad loader stub ELF\n");
+        return -1;
+    }
+    eph = (elf_pheader_t *)(boot_elf + eh->phoff);
+
+    memset((void *)0x00084000, 0, 0x00100000 - 0x00084000);
+
+    for (i = 0; i < eh->phnum; i++) {
+        if (eph[i].type != ELF_PT_LOAD)
+            continue;
+        pdata = (void *)(boot_elf + eph[i].offset);
+        memcpy(eph[i].vaddr, pdata, eph[i].filesz);
+        if (eph[i].memsz > eph[i].filesz)
+            memset((u8 *)eph[i].vaddr + eph[i].filesz, 0, eph[i].memsz - eph[i].filesz);
+    }
+
+    LOG("NEUTRINO loader handoff ELF=%s argc=%d\n", filename, argc + 2);
+    for (i = 0; i < argc + 2; i++)
+        LOG("execArgv[%d]=%s\n", i, execArgv[i]);
+
+    SifExitRpc();
+    FlushCache(0);
+    FlushCache(2);
+    return ExecPS2((void *)eh->entry, NULL, argc + 2, execArgv);
+}
+
+void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int EnablePS2Logo, const char *neutrinoPath, const char *neutrinoCwd, const char *vmc0, const char *vmc1)
 {
     char device[64];
+    char bsdfs[64];
     char filePath[256];
     char compatModes[64];
-    char *argv[6];
+    char cwd[256 + 5];
+    char mc0[256 + 5];
+    char mc1[256 + 5];
+    char *argv[12];
     int argc = 0;
 
     const char *deviceName = getDeviceName(driver);
-    if (!strncmp(deviceName, "apa", 3)) {
+    int isHDL = !strcmp(deviceName, "apa");
+
+    if (isHDL) {
         snprintf(device, sizeof(device), "-bsd=ata");
         argv[argc++] = device;
 
-        snprintf(device, sizeof(device), "-bsdfs=hdl");
-        argv[argc++] = device;
+        snprintf(bsdfs, sizeof(bsdfs), "-bsdfs=hdl");
+        argv[argc++] = bsdfs;
 
         snprintf(filePath, sizeof(filePath), "-dvd=hdl:%s", path);
         argv[argc++] = filePath;
@@ -1228,17 +1289,42 @@ void sysLaunchNeutrino(const char *driver, const char *path, int compatmask, int
         argv[argc++] = filePath;
     }
 
+    if (neutrinoCwd && neutrinoCwd[0]) {
+        snprintf(cwd, sizeof(cwd), "-cwd=%s", neutrinoCwd);
+        argv[argc++] = cwd;
+    }
+
+    if (vmc0 && vmc0[0]) {
+        snprintf(mc0, sizeof(mc0), "-mc0=%s", vmc0);
+        argv[argc++] = mc0;
+    }
+
+    if (vmc1 && vmc1[0]) {
+        snprintf(mc1, sizeof(mc1), "-mc1=%s", vmc1);
+        argv[argc++] = mc1;
+    }
+
     snprintf(compatModes, sizeof(compatModes), "-gc=%d", convertCompatmaskToModes(compatmask));
     argv[argc++] = compatModes;
-
-    LOG("COMPAT MODE ARG=%s\n", compatModes);
-    LOG("FILE PATH=%s\n", filePath);
 
     if (gEnableDebug)
         argv[argc++] = "-dbc";
 
-    if (EnablePS2Logo)
+    if (!isHDL)
+        argv[argc++] = "-qb";
+    else if (EnablePS2Logo)
         argv[argc++] = "-logo";
 
-    LoadELFFromFileWithPartition(neutrinoPath, "", argc, argv);
+    LOG("NEUTRINO ELF=%s\n", neutrinoPath);
+    LOG("NEUTRINO CWD=%s\n", neutrinoCwd ? neutrinoCwd : "");
+    LOG("VMC0=%s\n", vmc0 ? vmc0 : "");
+    LOG("VMC1=%s\n", vmc1 ? vmc1 : "");
+    LOG("COMPAT MODE ARG=%s\n", compatModes);
+    LOG("FILE PATH=%s\n", filePath);
+
+    LOG("Launching Neutrino: argc=%d\n", argc);
+    for (int i = 0; i < argc; i++)
+        LOG("argv[%d]=%s\n", i, argv[i]);
+
+    LoadNeutrinoELF(neutrinoPath, argc, argv);
 }


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Alright take 2.. I actually tested this time and it works on pcsx2.. The ps2sdk elf loader lib resets iop removing the loaded modules before neutrino startup hence the now embedded loader (taken from sdk I do not claim credit for this, all I did was comment out iop reset).. I would've liked to avoid embedding it since we already have the lib but it is what it is.. ideally sdk gets an update and iop reset is an arg option that way we can have other apps iop reset but neutrino not.. compile time option would still leave 2 separate loaders one for other apps one neutrino specific so not as ideal.. anyway it works now. For more details see my previous closed PR as I don't feel like writing a big spiel again :)

Codacy will probably complain again because it can’t trace the struct usage properly.. but this is intentional. I think it's cleaner than using static buffers..

edit: closes #197 