### PR TITLE
Change cfg save/load logic to use cwd()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifneq ($(GIT_TAG),latest)
 endif
 endif
 
-FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o lang.o lang_internal.o config_wopl.o config_migration.o dialogs.o tetris.o \
+FRONTEND_OBJS = pad.o xparam.o fntsys.o renderman.o menusys.o OSDHistory.o system.o lang.o lang_internal.o config_wopl.o pathsupport.o config_migration.o dialogs.o tetris.o \
 		dia.o ioman.o texcache.o themes.o supportbase.o bdmsupport.o ethsupport.o hddsupport.o lwnbd.o iosupport.o initializer.o zso.o lz4.o \
 		appsupport.o mmcesupport.o favsupport.o gui.o guigame.o vmc_groups.o textures.o tar.o common.o main.o module.o atlas.o nbns.o sound.o ps2cnf.o
 

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -8,8 +8,9 @@
 
 typedef struct
 {
-    int massDeviceIndex; // Underlying device index backing the mass fs partition, ex: usb0 = 0, usb1 = 1, etc.
-    char bdmPrefix[40];  // Contains the full path to the folder where all the games are.
+    int massDeviceIndex;    // Underlying BDM device index, ex: usb0 = 0, usb1 = 1, etc.
+    char bdmPrefix[40];     // Contains the full path to the folder where all the games are.
+    char bdmTruePrefix[16]; // Stable device identity.. ex: usb0:, mx4sio0:, ilink0:, ata0:
     int bdmULSizePrev;
     time_t bdmModifiedCDPrev;
     time_t bdmModifiedDVDPrev;
@@ -45,9 +46,10 @@ extern int gEnableBdmHDD;
 extern base_game_info_t *gAutoLaunchBDMGame;
 extern bdm_device_data_t *gAutoLaunchDeviceData;
 
-
-int bdmFindPartition(char *target, const char *name, int write);
 void bdmLoadModules(void);
+void bdmLoadModulesForPath(const char *path);
+void bdmLoadModulesForLegacyMass(void);
+void bdmLoadEnabledDeviceModules(void);
 void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg);
 
 void bdmInitSemaphore();
@@ -57,5 +59,8 @@ void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData);
 int bdmHDDIsPresent(u32 timeoutMs);
 
 void autoLaunchBDMGame(char *argv[]);
+
+int bdmResolveLegacyPath(char *out, size_t out_len, const char *path);
+int bdmResolveLegacyPathFromDeviceList(char *out, size_t out_len, const char *path);
 
 #endif

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -48,7 +48,7 @@ extern bdm_device_data_t *gAutoLaunchDeviceData;
 
 void bdmLoadModules(void);
 void bdmLoadModulesForPath(const char *path);
-void bdmLoadModulesForLegacyMass(void);
+void bdmLoadModulesForUsbMassCompat(void);
 void bdmLoadEnabledDeviceModules(void);
 void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg);
 
@@ -60,6 +60,6 @@ int bdmHDDIsPresent(u32 timeoutMs);
 
 void autoLaunchBDMGame(char *argv[]);
 
-int bdmResolveLegacyPath(char *out, size_t out_len, const char *path);
+int bdmResolveUsbMassCompatPath(char *out, size_t out_len, const char *path);
 
 #endif

--- a/include/bdmsupport.h
+++ b/include/bdmsupport.h
@@ -61,6 +61,5 @@ int bdmHDDIsPresent(u32 timeoutMs);
 void autoLaunchBDMGame(char *argv[]);
 
 int bdmResolveLegacyPath(char *out, size_t out_len, const char *path);
-int bdmResolveLegacyPathFromDeviceList(char *out, size_t out_len, const char *path);
 
 #endif

--- a/include/pathsupport.h
+++ b/include/pathsupport.h
@@ -7,6 +7,7 @@ void pathSetLaunchPath(const char *path);
 const char *pathGetLaunchPath(void);
 
 int pathIsDevicePath(const char *path);
+int pathIsLegacyMassPath(const char *path);
 void pathNormaliseDir(char *dir, size_t dir_len);
 int pathGetBootDir(char *dir_out, size_t dir_len);
 int pathResolveToTrue(char *out, size_t out_len, const char *path);

--- a/include/pathsupport.h
+++ b/include/pathsupport.h
@@ -1,0 +1,15 @@
+#ifndef PATHSUPPORT_H
+#define PATHSUPPORT_H
+
+#include <stddef.h>
+
+void pathSetLaunchPath(const char *path);
+const char *pathGetLaunchPath(void);
+
+int pathIsDevicePath(const char *path);
+void pathNormaliseDir(char *dir, size_t dir_len);
+int pathGetBootDir(char *dir_out, size_t dir_len);
+int pathResolveToTrue(char *out, size_t out_len, const char *path);
+int pathJoin(char *out, size_t out_len, const char *dir, const char *name);
+
+#endif

--- a/include/pathsupport.h
+++ b/include/pathsupport.h
@@ -6,11 +6,12 @@
 void pathSetLaunchPath(const char *path);
 const char *pathGetLaunchPath(void);
 
+int pathHasDevicePrefix(const char *path, const char *device);
+int pathParseDevicePrefix(const char *path, const char *device, int *index, const char **tail, int requireIndex);
 int pathIsDevicePath(const char *path);
-int pathIsLegacyMassPath(const char *path);
+int pathIsUsbMassCompatPath(const char *path);
 void pathNormaliseDir(char *dir, size_t dir_len);
 int pathGetBootDir(char *dir_out, size_t dir_len);
-int pathResolveToTrue(char *out, size_t out_len, const char *path);
 int pathJoin(char *out, size_t out_len, const char *dir, const char *name);
 
 #endif

--- a/include/supportbase.h
+++ b/include/supportbase.h
@@ -58,8 +58,9 @@ extern int gPadEmuSource;
 
 int isValidIsoName(char *name, int *pNameLen);
 int sbGetmcID(void);
+int sbCheckMC(void);
+int sbEnsureMCConfigFolder(const char *dir);
 int sbGetFileSize(int fd);
-void sbCheckMCFolder(void);
 int sbOpenFile(char *path, int mode);
 void *sbReadFile(char *path, int align, int *size);
 int sbIsSameSize(const char *prefix, int prevSize);

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -16,6 +16,7 @@
 #include "include/module.h"
 #include "include/initializer.h"
 #include "include/config_wopl.h"
+#include "include/pathsupport.h"
 #include <fcntl.h>
 #include <stdlib.h>
 #include <ps2sdkapi.h>
@@ -158,35 +159,15 @@ static void bdmLoadBlockDeviceModules(void)
     SignalSema(bdmLoadModuleLock);
 }
 
-static int bdmPathHasDevicePrefix(const char *path, const char *prefix)
-{
-    size_t len;
-
-    if (!path || !prefix)
-        return 0;
-
-    len = strlen(prefix);
-
-    if (strncmp(path, prefix, len))
-        return 0;
-
-    path += len;
-
-    while (*path >= '0' && *path <= '9')
-        path++;
-
-    return *path == ':';
-}
-
 static int bdmGetDeviceTypeFromPath(const char *path)
 {
-    if (bdmPathHasDevicePrefix(path, "usb"))
+    if (pathHasDevicePrefix(path, "usb"))
         return BDM_TYPE_USB;
-    if (bdmPathHasDevicePrefix(path, "ilink"))
+    if (pathHasDevicePrefix(path, "ilink"))
         return BDM_TYPE_ILINK;
-    if (bdmPathHasDevicePrefix(path, "mx4sio"))
+    if (pathHasDevicePrefix(path, "mx4sio"))
         return BDM_TYPE_SDC;
-    if (bdmPathHasDevicePrefix(path, "ata"))
+    if (pathHasDevicePrefix(path, "ata"))
         return BDM_TYPE_ATA;
 
     return BDM_TYPE_UNKNOWN;
@@ -257,17 +238,14 @@ void bdmLoadModulesForPath(const char *path)
     SignalSema(bdmLoadModuleLock);
 }
 
-void bdmLoadModulesForLegacyMass(void)
+void bdmLoadModulesForUsbMassCompat(void)
 {
-    LOG("BDMSUPPORT LoadModulesForLegacyMass\n");
+    LOG("BDMSUPPORT LoadModulesForUsbMassCompat\n");
 
     bdmLoadBaseModules();
 
     WaitSema(bdmLoadModuleLock);
     bdmLoadUSBModules();
-    //bdmLoadiLinkModules();
-    //bdmLoadMX4SIOModules();
-    bdmLoadBdmHDDModules();
     SignalSema(bdmLoadModuleLock);
 }
 
@@ -1138,42 +1116,6 @@ static int bdmOpenTrueDevice(int deviceType, int deviceIndex)
     return fileXioDopen(path);
 }
 
-static int bdmParseLegacyMassPath(const char *path, int *index, const char **tail)
-{
-    const char *p;
-    int value;
-
-    if (!path || strncmp(path, "mass", 4))
-        return 0;
-
-    p = path + 4;
-    value = -1;
-
-    // wLE seems to use mass: instead of mass0:
-    if (*p != ':') {
-        if (*p < '0' || *p > '9')
-            return 0;
-
-        value = 0;
-
-        while (*p >= '0' && *p <= '9') {
-            value = value * 10 + (*p - '0');
-            p++;
-        }
-    }
-
-    if (*p != ':')
-        return 0;
-
-    if (index)
-        *index = value;
-
-    if (tail)
-        *tail = p + 1;
-
-    return 1;
-}
-
 static int bdmSetDeviceTypeAndTruePrefix(bdm_device_data_t *pDeviceData, item_list_t *itemList, int deviceType, int deviceIndex)
 {
     if (!pDeviceData)
@@ -1221,7 +1163,7 @@ static int bdmSetupDeviceData(bdm_device_data_t *pDeviceData, item_list_t *itemL
     return 1;
 }
 
-static int bdmBuildResolvedLegacyCandidate(char *out, size_t out_len, const char *truePrefix, const char *tail)
+static int bdmBuildUsbMassCompatCandidate(char *out, size_t out_len, const char *truePrefix, const char *tail)
 {
     int len;
 
@@ -1241,7 +1183,7 @@ static int bdmBuildResolvedLegacyCandidate(char *out, size_t out_len, const char
     return 1;
 }
 
-static int bdmResolveLegacyPathPass(char *out, size_t out_len, const char *tail, int massIndex, int strictIndex)
+static int bdmResolveUsbMassCompatPathPass(char *out, size_t out_len, const char *tail, int massIndex, int strictIndex)
 {
     int i;
     struct stat st;
@@ -1256,17 +1198,20 @@ static int bdmResolveLegacyPathPass(char *out, size_t out_len, const char *tail,
         if (!pDeviceData || !pDeviceData->bdmTruePrefix[0])
             continue;
 
+        if (pDeviceData->bdmDeviceType != BDM_TYPE_USB)
+            continue;
+
         if (strictIndex && massIndex >= 0 && pDeviceData->massDeviceIndex != massIndex)
             continue;
 
-        if (!bdmBuildResolvedLegacyCandidate(candidate, sizeof(candidate), pDeviceData->bdmTruePrefix, tail))
+        if (!bdmBuildUsbMassCompatCandidate(candidate, sizeof(candidate), pDeviceData->bdmTruePrefix, tail))
             continue;
 
         if (stat(candidate, &st) != 0)
             continue;
 
         snprintf(out, out_len, "%s", candidate);
-        LOG("BDMSUPPORT: resolved legacy path from device list '%s'\n", out);
+        LOG("BDMSUPPORT: resolved USB mass compatibility path '%s'\n", out);
 
         return 1;
     }
@@ -1274,7 +1219,7 @@ static int bdmResolveLegacyPathPass(char *out, size_t out_len, const char *tail,
     return 0;
 }
 
-int bdmResolveLegacyPath(char *out, size_t out_len, const char *path)
+int bdmResolveUsbMassCompatPath(char *out, size_t out_len, const char *path)
 {
     const char *tail;
     int massIndex;
@@ -1282,18 +1227,18 @@ int bdmResolveLegacyPath(char *out, size_t out_len, const char *path)
     if (!out || !out_len || !path)
         return 0;
 
-    if (!bdmParseLegacyMassPath(path, &massIndex, &tail))
+    if (!pathParseDevicePrefix(path, "mass", &massIndex, &tail, 0))
         return 0;
 
     // First try a strict match using the reported BDM device number
-    if (bdmResolveLegacyPathPass(out, out_len, tail, massIndex, 1))
+    if (bdmResolveUsbMassCompatPathPass(out, out_len, tail, massIndex, 1))
         return 1;
 
     // Fallback wLE massN: does not always match the true BDM index
-    if (bdmResolveLegacyPathPass(out, out_len, tail, massIndex, 0))
+    if (bdmResolveUsbMassCompatPathPass(out, out_len, tail, massIndex, 0))
         return 1;
 
-    LOG("BDMSUPPORT: could not resolve legacy path from device list '%s'\n", path);
+    LOG("BDMSUPPORT: could not resolve USB mass compatibility path '%s'\n", path);
 
     return 0;
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -44,7 +44,8 @@ typedef struct
     vmc_spec_t specs; /* Card specifications */
 } bdm_vmc_infos_t;
 
-// static int usbModLoaded = 0;
+static int bdmModulesLoaded = 0;
+//static int usbModLoaded = 0;
 static int iLinkModLoaded = 0;
 static int mx4sioModLoaded = 0;
 static int hddModLoaded = 0;
@@ -63,7 +64,6 @@ int gEnableMX4SIO;
 int gEnableBdmHDD;
 base_game_info_t *gAutoLaunchBDMGame;
 bdm_device_data_t *gAutoLaunchDeviceData;
-
 
 void bdmInitDevicesData();
 int bdmUpdateDeviceData(item_list_t *itemList);
@@ -160,30 +160,34 @@ void bdmLoadModules(void)
 {
     LOG("BDMSUPPORT LoadModules\n");
 
-    guiSetBootStatusIfActive("Loading block device modules...");
+    if (!bdmModulesLoaded) {
+        guiSetBootStatusIfActive("Loading block device modules...");
 
-    // Load Block Device Manager (BDM)
-    LOG("[BDM]:\n");
-    sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
+        // Load Block Device Manager (BDM)
+        LOG("[BDM]:\n");
+        sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
 
-    // Load FATFS (mass:) driver
-    LOG("[BDMFS_FATFS]:\n");
-    sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
+        // Load FATFS (mass:) driver
+        LOG("[BDMFS_FATFS]:\n");
+        sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
 
-    guiSetBootStatusIfActive("Loading USB modules...");
+        guiSetBootStatusIfActive("Loading USB modules...");
 
-    LOG("[USBD]:\n");
-    sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
+        LOG("[USBD]:\n");
+        sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
 
-    LOG("[USBMASS_BD]:\n");
-    sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
+        LOG("[USBMASS_BD]:\n");
+        sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
+
+        LOG("[BDMEVENT]:\n");
+        sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
+        SifAddCmdHandler(0, &bdmEventHandler, NULL);
+
+        bdmModulesLoaded = 1;
+    }
 
     // Load Optional Block Device drivers
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
-
-    LOG("[BDMEVENT]:\n");
-    sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
-    SifAddCmdHandler(0, &bdmEventHandler, NULL);
 
     LOG("BDMSUPPORT Modules loaded\n");
 }
@@ -1165,45 +1169,33 @@ static int bdmGetATADeviceId()
 
 int bdmHDDIsPresent(u32 timeoutMs)
 {
-    int hdd_id = -1;
-    int timedout = 0;
+    const int RETRY_DELAY = 100; // ms
+    u32 start;
 
     if (!hddIsPresent())
         return 0;
 
-    // 1. scan via normal methods first...
-    hdd_id = bdmGetATADeviceId();
-    if (hdd_id >= 0)
+    if (bdmGetATADeviceId() >= 0)
         return 1;
 
-    // 2. try to scan as fast as possible if the previous scan fails...
-    hdd_id = 0;
+    if (timeoutMs == 0)
+        return 0;
 
-    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
-        // find the first inaccessible device - this one should be the HDD once it's mounted (we don't have access to device data at this point yet!)
-        if (!bdmDeviceIsPresent(i)) {
-            hdd_id = i;
+    start = GetTimerSystemTime();
+
+    while (1) {
+        u32 elapsed_ms = (GetTimerSystemTime() - start) / (kBUSCLK / 1000);
+
+        if (elapsed_ms >= timeoutMs)
             break;
-        }
-    }
 
-    if (bdmWaitForDevice(hdd_id, timeoutMs)) {
-        // double-check to see if this indeed is the HDD, and if it is, we can exit early without stalling any further
-        if (bdmDeviceIsATA(hdd_id)) {
+        DelayThread(RETRY_DELAY * 1000);
+
+        if (bdmGetATADeviceId() >= 0)
             return 1;
-        } else
-            LOG("bdmHDDIsPresent: device at id %d is not an ATA HDD...\n", hdd_id);
-    } else {
-        timedout = 1;
-        LOG("bdmHDDIsPresent: waiting for hdd at id %d timed out...\n", hdd_id);
     }
 
-    // 3. last resort - time out (if needed) and scan again...
-    if (!timedout) {
-        // if we haven't timed out already, then we need to wait for the devices to wake up... wait for the timeout...
-        LOG("bdmHDDIsPresent: waiting for timeout before scanning again...\n", hdd_id);
-        DelayThread(timeoutMs * 1000);
-    }
+    LOG("bdmHDDIsPresent: waiting for BDM ATA device timed out.\n");
 
-    return bdmGetATADeviceId() >= 0;
+    return 0;
 }

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -34,7 +34,7 @@
 
 #define BDM_MODE_UPDATE_DELAY MENU_UPD_DELAY_GENREFRESH
 
-#define MAX_BDM_TRUE_DEVICES (MAX_BDM_DEVICES * 4)
+#define MAX_BDM_TRUE_DEVICES MAX_BDM_DEVICES
 
 #include "include/mcemu.h"
 
@@ -139,24 +139,6 @@ static void bdmLoadBdmHDDModules(void)
     }
 }
 
-static void bdmLoadBlockDeviceModulesForType(int deviceType)
-{
-    switch (deviceType) {
-        case BDM_TYPE_USB:
-            bdmLoadUSBModules();
-            break;
-        case BDM_TYPE_ILINK:
-            bdmLoadiLinkModules();
-            break;
-        case BDM_TYPE_SDC:
-            bdmLoadMX4SIOModules();
-            break;
-        case BDM_TYPE_ATA:
-            bdmLoadBdmHDDModules();
-            break;
-    }
-}
-
 static void bdmLoadBlockDeviceModules(void)
 {
     WaitSema(bdmLoadModuleLock);
@@ -256,7 +238,22 @@ void bdmLoadModulesForPath(const char *path)
     bdmLoadBaseModules();
 
     WaitSema(bdmLoadModuleLock);
-    bdmLoadBlockDeviceModulesForType(deviceType);
+
+    switch (deviceType) {
+        case BDM_TYPE_USB:
+            bdmLoadUSBModules();
+            break;
+        case BDM_TYPE_ILINK:
+            bdmLoadiLinkModules();
+            break;
+        case BDM_TYPE_SDC:
+            bdmLoadMX4SIOModules();
+            break;
+        case BDM_TYPE_ATA:
+            bdmLoadBdmHDDModules();
+            break;
+    }
+
     SignalSema(bdmLoadModuleLock);
 }
 
@@ -277,6 +274,11 @@ void bdmLoadModulesForLegacyMass(void)
 void bdmLoadEnabledDeviceModules(void)
 {
     LOG("BDMSUPPORT LoadEnabledDeviceModules\n");
+
+    if (!gEnableUSB && !gEnableILK && !gEnableMX4SIO && !gEnableBdmHDD) {
+        LOG("BDMSUPPORT no enabled BDM devices\n");
+        return;
+    }
 
     bdmLoadBaseModules();
 
@@ -1004,7 +1006,7 @@ void bdmInitDevicesData()
             // Setup the device list item.
             item_list_t *pDeviceSupport = &bdmDeviceList[i];
             memcpy(pDeviceSupport, &bdmGameList, sizeof(item_list_t));
-            pDeviceSupport->mode = i;
+            pDeviceSupport->mode = BDM_MODE + i;
 
             // Setup the per-device data.
             bdm_device_data_t *pDeviceData = (bdm_device_data_t *)malloc(sizeof(bdm_device_data_t));
@@ -1021,7 +1023,7 @@ void bdmInitDevicesData()
     // Refresh the visibility of the menu.
     for (int i = 0; i < MAX_BDM_TRUE_DEVICES; i++) {
         // Register the device structure into the UI.
-        initSupport(&bdmDeviceList[i], i, 0);
+        initSupport(&bdmDeviceList[i], BDM_MODE + i, 0);
 
         // If bdm support is set to auto then make the page invisible and reset the bdm tick counter, when a bdm device is mounted it will dynamically be made visible.
         // If bdm support is set to manual then only make the first page visible.
@@ -1219,71 +1221,6 @@ static int bdmSetupDeviceData(bdm_device_data_t *pDeviceData, item_list_t *itemL
     return 1;
 }
 
-int bdmResolveLegacyPath(char *out, size_t out_len, const char *path)
-{
-    char massPath[16];
-    char truePrefix[16];
-    char driver[32];
-    const char *tail;
-    int massIndex;
-    int deviceIndex;
-    int deviceType;
-    int dir;
-    int len;
-
-    if (!out || !out_len || !path)
-        return 0;
-
-    if (!bdmParseLegacyMassPath(path, &massIndex, &tail))
-        return 0;
-
-    if (massIndex >= 0)
-        len = snprintf(massPath, sizeof(massPath), "mass%d:/", massIndex);
-    else
-        len = snprintf(massPath, sizeof(massPath), "mass:/");
-
-    if (len < 0 || (size_t)len >= sizeof(massPath))
-        return 0;
-
-    dir = fileXioDopen(massPath);
-    if (dir < 0) {
-        LOG("BDMSUPPORT: failed to open legacy path root '%s'\n", massPath);
-        return 0;
-    }
-
-    memset(driver, 0, sizeof(driver));
-    deviceIndex = massIndex >= 0 ? massIndex : 0;
-
-    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driver, sizeof(driver) - 1);
-    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &deviceIndex, sizeof(deviceIndex));
-
-    fileXioDclose(dir);
-
-    if (!strcmp(driver, "usb"))
-        deviceType = BDM_TYPE_USB;
-    else if (!strcmp(driver, "sdc") && strlen(driver) == 3)
-        deviceType = BDM_TYPE_SDC;
-    else if (!strcmp(driver, "sd") && strlen(driver) == 2)
-        deviceType = BDM_TYPE_ILINK;
-    else if (!strcmp(driver, "ata") && strlen(driver) == 3)
-        deviceType = BDM_TYPE_ATA;
-    else
-        return 0;
-
-    if (!bdmBuildTruePath(truePrefix, sizeof(truePrefix), deviceType, deviceIndex, 0))
-        return 0;
-
-    len = snprintf(out, out_len, "%s%s", truePrefix, tail);
-    if (len < 0 || (size_t)len >= out_len) {
-        out[0] = '\0';
-        return 0;
-    }
-
-    LOG("BDMSUPPORT: resolved legacy path '%s' -> '%s'\n", path, out);
-
-    return 1;
-}
-
 static int bdmBuildResolvedLegacyCandidate(char *out, size_t out_len, const char *truePrefix, const char *tail)
 {
     int len;
@@ -1304,7 +1241,7 @@ static int bdmBuildResolvedLegacyCandidate(char *out, size_t out_len, const char
     return 1;
 }
 
-static int bdmResolveLegacyPathFromDeviceListPass(char *out, size_t out_len, const char *tail, int massIndex, int strictIndex)
+static int bdmResolveLegacyPathPass(char *out, size_t out_len, const char *tail, int massIndex, int strictIndex)
 {
     int i;
     struct stat st;
@@ -1337,7 +1274,7 @@ static int bdmResolveLegacyPathFromDeviceListPass(char *out, size_t out_len, con
     return 0;
 }
 
-int bdmResolveLegacyPathFromDeviceList(char *out, size_t out_len, const char *path)
+int bdmResolveLegacyPath(char *out, size_t out_len, const char *path)
 {
     const char *tail;
     int massIndex;
@@ -1349,11 +1286,11 @@ int bdmResolveLegacyPathFromDeviceList(char *out, size_t out_len, const char *pa
         return 0;
 
     // First try a strict match using the reported BDM device number
-    if (bdmResolveLegacyPathFromDeviceListPass(out, out_len, tail, massIndex, 1))
+    if (bdmResolveLegacyPathPass(out, out_len, tail, massIndex, 1))
         return 1;
 
     // Fallback wLE massN: does not always match the true BDM index
-    if (bdmResolveLegacyPathFromDeviceListPass(out, out_len, tail, massIndex, 0))
+    if (bdmResolveLegacyPathPass(out, out_len, tail, massIndex, 0))
         return 1;
 
     LOG("BDMSUPPORT: could not resolve legacy path from device list '%s'\n", path);
@@ -1379,27 +1316,33 @@ int bdmUpdateDeviceData(item_list_t *itemList)
 
     int visible = itemList->owner != NULL ? ((opl_io_module_t *)itemList->owner)->menuItem.visible : 0;
 
-    deviceIndex = itemList->mode % MAX_BDM_DEVICES;
+    int slotIndex = itemList->mode - BDM_MODE;
+    int found = 0;
+    int dir = -1;
 
-    switch (itemList->mode / MAX_BDM_DEVICES) {
-        case 0:
-            deviceType = BDM_TYPE_USB;
-            break;
-        case 1:
-            deviceType = BDM_TYPE_ILINK;
-            break;
-        case 2:
-            deviceType = BDM_TYPE_SDC;
-            break;
-        case 3:
-            deviceType = BDM_TYPE_ATA;
-            break;
-        default:
-            return 0;
+    if (slotIndex < 0 || slotIndex >= MAX_BDM_DEVICES)
+        return 0;
+
+    for (int type = BDM_TYPE_USB; type <= BDM_TYPE_ATA && dir < 0; type++) {
+        if ((type == BDM_TYPE_USB && !gEnableUSB) || (type == BDM_TYPE_ILINK && !gEnableILK) || (type == BDM_TYPE_SDC && !gEnableMX4SIO) || (type == BDM_TYPE_ATA && !gEnableBdmHDD))
+            continue;
+
+        for (int index = 0; index < MAX_BDM_DEVICES; index++) {
+            int testDir = bdmOpenTrueDevice(type, index);
+            if (testDir < 0)
+                continue;
+
+            if (found == slotIndex) {
+                deviceType = type;
+                deviceIndex = index;
+                dir = testDir;
+                break;
+            }
+
+            fileXioDclose(testDir);
+            found++;
+        }
     }
-
-    // Try to open the device by its real BDM prefix.
-    int dir = bdmOpenTrueDevice(deviceType, deviceIndex);
     // LOG("opendir %s -> %d\n", path, dir);
 
     // If we opened the device and the menu isn't visible (OR is visible but hasn't been initialized ex: manual device start) initialize device info.

--- a/src/bdmsupport.c
+++ b/src/bdmsupport.c
@@ -34,6 +34,8 @@
 
 #define BDM_MODE_UPDATE_DELAY MENU_UPD_DELAY_GENREFRESH
 
+#define MAX_BDM_TRUE_DEVICES (MAX_BDM_DEVICES * 4)
+
 #include "include/mcemu.h"
 
 typedef struct
@@ -45,13 +47,13 @@ typedef struct
 } bdm_vmc_infos_t;
 
 static int bdmModulesLoaded = 0;
-//static int usbModLoaded = 0;
+static int usbModLoaded = 0;
 static int iLinkModLoaded = 0;
 static int mx4sioModLoaded = 0;
 static int hddModLoaded = 0;
 static s32 bdmLoadModuleLock;
 
-static item_list_t bdmDeviceList[MAX_BDM_DEVICES];
+static item_list_t bdmDeviceList[MAX_BDM_TRUE_DEVICES];
 static int bdmDeviceListInitialized = 0;
 
 int bdmDeviceModeStarted;
@@ -68,39 +70,9 @@ bdm_device_data_t *gAutoLaunchDeviceData;
 void bdmInitDevicesData();
 int bdmUpdateDeviceData(item_list_t *itemList);
 
-// Identifies the partition that the specified file is stored on and generates a full path to it.
-int bdmFindPartition(char *target, const char *name, int write)
-{
-    int i, fd;
-    char path[256];
-
-    for (i = 0; i < MAX_BDM_DEVICES; i++) {
-        if (gBDMPrefix[0] != '\0')
-            sprintf(path, "mass%d:%s/%s", i, gBDMPrefix, name);
-        else
-            sprintf(path, "mass%d:%s", i, name);
-        if (write)
-            fd = open(path, O_WRONLY | O_TRUNC | O_CREAT, 0666);
-        else
-            fd = open(path, O_RDONLY);
-
-        if (fd >= 0) {
-            if (gBDMPrefix[0] != '\0')
-                sprintf(target, "mass%d:%s/", i, gBDMPrefix);
-            else
-                sprintf(target, "mass%d:", i);
-            close(fd);
-            return 1;
-        }
-    }
-
-    // default to first partition (for themes, ...)
-    if (gBDMPrefix[0] != '\0')
-        sprintf(target, "mass0:%s/", gBDMPrefix);
-    else
-        sprintf(target, "mass0:");
-    return 0;
-}
+static const char *bdmGetDevicePrefix(int deviceType);
+static int bdmBuildTruePath(char *path, size_t pathSize, int deviceType, int deviceIndex, int withSlash);
+static int bdmOpenTrueDevice(int deviceType, int deviceIndex);
 
 static unsigned int BdmGeneration = 0;
 
@@ -109,31 +81,41 @@ static void bdmEventHandler(void *packet, void *opt)
     BdmGeneration++;
 }
 
-static void bdmLoadBlockDeviceModules(void)
+static void bdmLoadUSBModules(void)
 {
-    WaitSema(bdmLoadModuleLock);
+    if (!usbModLoaded) {
+        guiSetBootStatusIfActive("Loading USB modules...");
 
-    /*if (gEnableUSB && !usbModLoaded) {
         // Load USB Block Device drivers
+        LOG("[USBD]:\n");
+        sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
+
         LOG("[USBMASS_BD]:\n");
         sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
 
         usbModLoaded = 1;
-    }*/
+    }
+}
 
-    if (gEnableILK && !iLinkModLoaded) {
+static void bdmLoadiLinkModules(void)
+{
+    if (!iLinkModLoaded) {
         guiSetBootStatusIfActive("Loading iLink modules...");
 
         // Load iLink Block Device drivers
         LOG("[ILINKMAN]:\n");
         sysLoadModuleBuffer(&iLinkman_irx, size_iLinkman_irx, 0, NULL);
+
         LOG("[IEEE1394_BD]:\n");
         sysLoadModuleBuffer(&IEEE1394_bd_irx, size_IEEE1394_bd_irx, 0, NULL);
 
         iLinkModLoaded = 1;
     }
+}
 
-    if (gEnableMX4SIO && !mx4sioModLoaded) {
+static void bdmLoadMX4SIOModules(void)
+{
+    if (!mx4sioModLoaded) {
         guiSetBootStatusIfActive("Loading MX4SIO modules...");
 
         // Load MX4SIO Block Device drivers
@@ -142,8 +124,11 @@ static void bdmLoadBlockDeviceModules(void)
 
         mx4sioModLoaded = 1;
     }
+}
 
-    if (gEnableBdmHDD && !hddModLoaded) {
+static void bdmLoadBdmHDDModules(void)
+{
+    if (!hddModLoaded) {
         guiSetBootStatusIfActive("Loading BDM HDD modules...");
 
         // Load dev9 and atad device drivers.
@@ -152,14 +137,81 @@ static void bdmLoadBlockDeviceModules(void)
 
         hddModLoaded = 1;
     }
+}
+
+static void bdmLoadBlockDeviceModulesForType(int deviceType)
+{
+    switch (deviceType) {
+        case BDM_TYPE_USB:
+            bdmLoadUSBModules();
+            break;
+        case BDM_TYPE_ILINK:
+            bdmLoadiLinkModules();
+            break;
+        case BDM_TYPE_SDC:
+            bdmLoadMX4SIOModules();
+            break;
+        case BDM_TYPE_ATA:
+            bdmLoadBdmHDDModules();
+            break;
+    }
+}
+
+static void bdmLoadBlockDeviceModules(void)
+{
+    WaitSema(bdmLoadModuleLock);
+
+    if (gEnableUSB)
+        bdmLoadUSBModules();
+
+    if (gEnableILK)
+        bdmLoadiLinkModules();
+
+    if (gEnableMX4SIO)
+        bdmLoadMX4SIOModules();
+
+    if (gEnableBdmHDD)
+        bdmLoadBdmHDDModules();
 
     SignalSema(bdmLoadModuleLock);
 }
 
-void bdmLoadModules(void)
+static int bdmPathHasDevicePrefix(const char *path, const char *prefix)
 {
-    LOG("BDMSUPPORT LoadModules\n");
+    size_t len;
 
+    if (!path || !prefix)
+        return 0;
+
+    len = strlen(prefix);
+
+    if (strncmp(path, prefix, len))
+        return 0;
+
+    path += len;
+
+    while (*path >= '0' && *path <= '9')
+        path++;
+
+    return *path == ':';
+}
+
+static int bdmGetDeviceTypeFromPath(const char *path)
+{
+    if (bdmPathHasDevicePrefix(path, "usb"))
+        return BDM_TYPE_USB;
+    if (bdmPathHasDevicePrefix(path, "ilink"))
+        return BDM_TYPE_ILINK;
+    if (bdmPathHasDevicePrefix(path, "mx4sio"))
+        return BDM_TYPE_SDC;
+    if (bdmPathHasDevicePrefix(path, "ata"))
+        return BDM_TYPE_ATA;
+
+    return BDM_TYPE_UNKNOWN;
+}
+
+static void bdmLoadBaseModules(void)
+{
     if (!bdmModulesLoaded) {
         guiSetBootStatusIfActive("Loading block device modules...");
 
@@ -167,24 +219,24 @@ void bdmLoadModules(void)
         LOG("[BDM]:\n");
         sysLoadModuleBuffer(&bdm_irx, size_bdm_irx, 0, NULL);
 
-        // Load FATFS (mass:) driver
+        // Load BDM FATFS driver
         LOG("[BDMFS_FATFS]:\n");
         sysLoadModuleBuffer(&bdmfs_fatfs_irx, size_bdmfs_fatfs_irx, 0, NULL);
 
-        guiSetBootStatusIfActive("Loading USB modules...");
-
-        LOG("[USBD]:\n");
-        sysLoadModuleBuffer(&usbd_irx, size_usbd_irx, 0, NULL);
-
-        LOG("[USBMASS_BD]:\n");
-        sysLoadModuleBuffer(&usbmass_bd_irx, size_usbmass_bd_irx, 0, NULL);
-
         LOG("[BDMEVENT]:\n");
         sysLoadModuleBuffer(&bdmevent_irx, size_bdmevent_irx, 0, NULL);
+
         SifAddCmdHandler(0, &bdmEventHandler, NULL);
 
         bdmModulesLoaded = 1;
     }
+}
+
+void bdmLoadModules(void)
+{
+    LOG("BDMSUPPORT LoadModules\n");
+
+    bdmLoadBaseModules();
 
     // Load Optional Block Device drivers
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
@@ -192,11 +244,56 @@ void bdmLoadModules(void)
     LOG("BDMSUPPORT Modules loaded\n");
 }
 
+void bdmLoadModulesForPath(const char *path)
+{
+    int deviceType = bdmGetDeviceTypeFromPath(path);
+
+    if (deviceType == BDM_TYPE_UNKNOWN)
+        return;
+
+    LOG("BDMSUPPORT LoadModulesForPath %s\n", path);
+
+    bdmLoadBaseModules();
+
+    WaitSema(bdmLoadModuleLock);
+    bdmLoadBlockDeviceModulesForType(deviceType);
+    SignalSema(bdmLoadModuleLock);
+}
+
+void bdmLoadModulesForLegacyMass(void)
+{
+    LOG("BDMSUPPORT LoadModulesForLegacyMass\n");
+
+    bdmLoadBaseModules();
+
+    WaitSema(bdmLoadModuleLock);
+    bdmLoadUSBModules();
+    //bdmLoadiLinkModules();
+    //bdmLoadMX4SIOModules();
+    bdmLoadBdmHDDModules();
+    SignalSema(bdmLoadModuleLock);
+}
+
+void bdmLoadEnabledDeviceModules(void)
+{
+    LOG("BDMSUPPORT LoadEnabledDeviceModules\n");
+
+    bdmLoadBaseModules();
+
+    // Settings have now been loaded.. so load enabled BDM drivers synchronously before bdmEnumerateDevices() runs
+    bdmLoadBlockDeviceModules();
+}
+
 static void bdmInit(item_list_t *itemList)
 {
     LOG("BDMSUPPORT Init\n");
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    if (!pDeviceData) {
+        itemList->enabled = 0;
+        return;
+    }
+
     pDeviceData->bdmULSizePrev = -2;
     pDeviceData->bdmModifiedCDPrev = 0;
     pDeviceData->bdmModifiedDVDPrev = 0;
@@ -221,6 +318,11 @@ static int bdmNeedsUpdate(item_list_t *itemList)
         return 0;
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+    if (!pDeviceData)
+        return 0;
+
+    opl_io_module_t *pOwner = (opl_io_module_t *)itemList->owner;
+    int visible = pOwner != NULL && pOwner->menuItem.visible == 1;
 
     ioPutRequest(IO_CUSTOM_SIMPLEACTION, &bdmLoadBlockDeviceModules);
 
@@ -232,8 +334,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
 
     // If the device menu is visible double check the device type and if support for this device type is enabled. If the user switches device support
     // to off for a bdm device we want to hide the menu even though the drivers are still loaded and the device is being detected by bdm.
-    opl_io_module_t *pOwner = (opl_io_module_t *)itemList->owner;
-    if (pOwner != NULL && pOwner->menuItem.visible == 1) {
+    if (visible) {
         int deviceEnabled = 0;
         switch (pDeviceData->bdmDeviceType) {
             case BDM_TYPE_USB:
@@ -260,6 +361,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
 
     if (pDeviceData->bdmULSizePrev != -2 && pDeviceData->bdmDeviceTick == BdmGeneration)
         return 0;
+
     pDeviceData->bdmDeviceTick = BdmGeneration;
 
     // Check if the device has been connected or removed.
@@ -273,7 +375,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     } else if (result == 1)
         sfxPlay(SFX_BD_CONNECT);
 
-    sprintf(path, "%sCD", pDeviceData->bdmPrefix);
+    snprintf(path, sizeof(path), "%sCD", pDeviceData->bdmPrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
     if (pDeviceData->bdmModifiedCDPrev != st.st_mtime) {
@@ -281,7 +383,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
         result = 1;
     }
 
-    sprintf(path, "%sDVD", pDeviceData->bdmPrefix);
+    snprintf(path, sizeof(path), "%sDVD", pDeviceData->bdmPrefix);
     if (stat(path, &st) != 0)
         st.st_mtime = 0;
     if (pDeviceData->bdmModifiedDVDPrev != st.st_mtime) {
@@ -296,7 +398,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     if (!pDeviceData->ThemesLoaded) {
         guiSetBootStatusIfActive("Loading block device themes...");
 
-        sprintf(path, "%sTHM", pDeviceData->bdmPrefix);
+        snprintf(path, sizeof(path), "%sTHM", pDeviceData->bdmPrefix);
         if (thmAddElements(path, "/", 1) > 0)
             pDeviceData->ThemesLoaded = 1;
     }
@@ -305,7 +407,7 @@ static int bdmNeedsUpdate(item_list_t *itemList)
     if (!pDeviceData->LanguagesLoaded) {
         guiSetBootStatusIfActive("Loading block device languages...");
 
-        sprintf(path, "%sLNG", pDeviceData->bdmPrefix);
+        snprintf(path, sizeof(path), "%sLNG", pDeviceData->bdmPrefix);
         if (lngAddLanguages(path, "/", itemList->mode) > 0)
             pDeviceData->LanguagesLoaded = 1;
     }
@@ -449,7 +551,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
                     bdm_vmc_infos.specs.block_size = vmc_superblock.pages_per_block;
                     bdm_vmc_infos.specs.card_size = vmc_superblock.pages_per_cluster * vmc_superblock.clusters_per_card;
 
-                    sprintf(vmc_path, "%sVMC/%s.bin", pDeviceData->bdmPrefix, vmc_name);
+                    snprintf(vmc_path, sizeof(vmc_path), "%sVMC/%s.bin", pDeviceData->bdmPrefix, vmc_name);
 
                     fd = open(vmc_path, O_RDONLY);
                     if (fd >= 0) {
@@ -508,7 +610,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
 
     void *irx = NULL;
     int irx_size = 0;
-    if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3) {
+    if (pDeviceData->bdmDeviceType == BDM_TYPE_ATA) {
         irx = &bdm_ata_cdvdman_irx;
         irx_size = size_bdm_ata_cdvdman_irx;
     } else {
@@ -621,12 +723,23 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         filename[sizeof(filename) - 1] = '\0';
     }
 
-    // deinit will free per device data.. copy driver name before free to compare for launch
-    char bdmCurrentDriver[32];
-    snprintf(bdmCurrentDriver, sizeof(bdmCurrentDriver), "%s", pDeviceData->bdmDriver);
+    // deinit will free per device data.. copy resolved device info before free to compare for launch
+    char bdmCurrentDevice[16];
+    int bdmCurrentType = pDeviceData->bdmDeviceType;
+
+    snprintf(bdmCurrentDevice, sizeof(bdmCurrentDevice), "%s", pDeviceData->bdmTruePrefix);
     settings->bdDeviceId = pDeviceData->massDeviceIndex;
 
-    if (!strcmp(bdmCurrentDriver, "ata") && strlen(bdmCurrentDriver) == 3) {
+    if (bdmCurrentType != BDM_TYPE_USB && bdmCurrentType != BDM_TYPE_ILINK && bdmCurrentType != BDM_TYPE_SDC && bdmCurrentType != BDM_TYPE_ATA) {
+        LOG("BDMSUPPORT: unsupported BDM device type %d (%s)\n", bdmCurrentType, bdmCurrentDevice);
+
+        if (gAutoLaunchBDMGame == NULL)
+            guiMsgBox(_l(_STR_ERR_FILE_INVALID), 0, NULL);
+
+        return;
+    }
+
+    if (bdmCurrentType == BDM_TYPE_ATA) {
         // Get DMA settings for ATA mode.
         int dmaType = 0, dmaMode = 7;
         dmaMode = (pgcfg->dma != 7) ? pgcfg->dma : 7;
@@ -657,7 +770,7 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
         sbMMCESendGameId(game->startup);
 
     int deinitException = NO_EXCEPTION;
-    int deinitMode = itemList->mode;
+    int deinitMode = gAutoLaunchBDMGame == NULL ? itemList->mode : BDM_MODE;
 
     if (selectedCore == CORE_LOADER_NEUTRINO) {
         int elfDevice = -1;
@@ -686,26 +799,39 @@ void bdmLaunchGame(item_list_t *itemList, int id, per_game_cfg_t *pgcfg)
     LOG("bdm pre sysLaunchLoaderElf\n");
 
     if (selectedCore == CORE_LOADER_NEUTRINO) {
-        sysLaunchNeutrino(bdmCurrentDriver, partname, compatmask, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
+        sysLaunchNeutrino(bdmCurrentDevice, partname, compatmask, EnablePS2Logo, neutrinoPath.elf, neutrinoPath.cwd, neutrinoVmc0, neutrinoVmc1);
         return;
     }
 
-    if (!strcmp(bdmCurrentDriver, "usb")) {
-        settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
-        if (settings->bdDeviceId == 0)
-            sysLaunchLoaderElf(filename, "BDM_USB_MODE0", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-        else
-            sysLaunchLoaderElf(filename, "BDM_USB_MODE1", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(bdmCurrentDriver, "sd") && strlen(bdmCurrentDriver) == 2) {
-        settings->common.fakemodule_flags |= 0 /* TODO! fake ilinkman ? */;
-        sysLaunchLoaderElf(filename, "BDM_ILK_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(bdmCurrentDriver, "sdc") && strlen(bdmCurrentDriver) == 3) {
-        settings->common.fakemodule_flags |= 0;
-        sysLaunchLoaderElf(filename, "BDM_M4S_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
-    } else if (!strcmp(bdmCurrentDriver, "ata") && strlen(bdmCurrentDriver) == 3) {
-        settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
-        settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_ATAD;
-        sysLaunchLoaderElf(filename, "BDM_ATA_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
+    switch (bdmCurrentType) {
+        case BDM_TYPE_USB:
+            settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_USBD;
+
+            if (settings->bdDeviceId == 0)
+                sysLaunchLoaderElf(filename, "BDM_USB_MODE0", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
+            else
+                sysLaunchLoaderElf(filename, "BDM_USB_MODE1", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
+            break;
+
+        case BDM_TYPE_ILINK:
+            settings->common.fakemodule_flags |= 0 /* TODO! fake ilinkman ? */;
+            sysLaunchLoaderElf(filename, "BDM_ILK_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
+            break;
+
+        case BDM_TYPE_SDC:
+            settings->common.fakemodule_flags |= 0;
+            sysLaunchLoaderElf(filename, "BDM_M4S_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
+            break;
+
+        case BDM_TYPE_ATA:
+            settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_DEV9;
+            settings->common.fakemodule_flags |= FAKE_MODULE_FLAG_ATAD;
+            sysLaunchLoaderElf(filename, "BDM_ATA_MODE", irx_size, irx, size_mcemu_irx, bdm_mcemu_irx, EnablePS2Logo, compatmask);
+            break;
+
+        default:
+            LOG("BDMSUPPORT: invalid BDM device type after deinit: %d\n", bdmCurrentType); // dont see how this would ever happen.. but..
+            break;
     }
 }
 
@@ -756,14 +882,20 @@ static int bdmGetTextId(item_list_t *itemList)
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (!strcmp(pDeviceData->bdmDriver, "usb"))
-        mode = _STR_USB_GAMES;
-    else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2)
-        mode = _STR_ILINK_GAMES;
-    else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3)
-        mode = _STR_MX4SIO_GAMES;
-    else if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3)
-        mode = _STR_HDD_GAMES;
+    switch (pDeviceData->bdmDeviceType) {
+        case BDM_TYPE_USB:
+            mode = _STR_USB_GAMES;
+            break;
+        case BDM_TYPE_ILINK:
+            mode = _STR_ILINK_GAMES;
+            break;
+        case BDM_TYPE_SDC:
+            mode = _STR_MX4SIO_GAMES;
+            break;
+        case BDM_TYPE_ATA:
+            mode = _STR_HDD_GAMES;
+            break;
+    }
 
     return mode;
 }
@@ -774,14 +906,20 @@ static int bdmGetIconId(item_list_t *itemList)
 
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
 
-    if (!strcmp(pDeviceData->bdmDriver, "usb"))
-        mode = USB_ICON;
-    else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2)
-        mode = ILINK_ICON;
-    else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3)
-        mode = MX4SIO_ICON;
-    else if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3)
-        mode = HDD_BD_ICON;
+    switch (pDeviceData->bdmDeviceType) {
+        case BDM_TYPE_USB:
+            mode = USB_ICON;
+            break;
+        case BDM_TYPE_ILINK:
+            mode = ILINK_ICON;
+            break;
+        case BDM_TYPE_SDC:
+            mode = MX4SIO_ICON;
+            break;
+        case BDM_TYPE_ATA:
+            mode = HDD_BD_ICON;
+            break;
+    }
 
     return mode;
 }
@@ -793,6 +931,9 @@ static void bdmCleanUp(item_list_t *itemList, int exception)
         LOG("BDMSUPPORT CleanUp\n");
 
         bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
+        if (!pDeviceData)
+            return;
+
         free(pDeviceData->bdmGames);
         free(pDeviceData);
         itemList->priv = NULL;
@@ -809,15 +950,14 @@ static void bdmShutdown(item_list_t *itemList)
 
     LOG("BDMSUPPORT Shutdown\n");
 
-    // Format the device path.
-    // Getting the device number is only relevant per module ie usb0 and mx40 will result in both being massDeviceIndex = 0 or mass0, use mode to determine instead.
     bdm_device_data_t *pDeviceData = (bdm_device_data_t *)itemList->priv;
-    snprintf(path, sizeof(path), "mass%d:", itemList->mode);
 
-    // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
-    fileXioDevctl(path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    if (pDeviceData && bdmBuildTruePath(path, sizeof(path), pDeviceData->bdmDeviceType, pDeviceData->massDeviceIndex, 0)) {
+        // As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
+        fileXioDevctl(path, USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+    }
 
-    if (itemList->enabled) {
+    if (itemList->enabled && pDeviceData) {
         LOG("BDMSUPPORT Shutdown free data\n");
 
         // Free device data.
@@ -860,7 +1000,7 @@ void bdmInitDevicesData()
     if (bdmDeviceListInitialized == 0) {
         bdmDeviceListInitialized = 1;
 
-        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+        for (int i = 0; i < MAX_BDM_TRUE_DEVICES; i++) {
             // Setup the device list item.
             item_list_t *pDeviceSupport = &bdmDeviceList[i];
             memcpy(pDeviceSupport, &bdmGameList, sizeof(item_list_t));
@@ -868,13 +1008,18 @@ void bdmInitDevicesData()
 
             // Setup the per-device data.
             bdm_device_data_t *pDeviceData = (bdm_device_data_t *)malloc(sizeof(bdm_device_data_t));
+            if (!pDeviceData) {
+                pDeviceSupport->priv = NULL;
+                continue;
+            }
+
             memset(pDeviceData, 0, sizeof(bdm_device_data_t));
             pDeviceSupport->priv = pDeviceData;
         }
     }
 
     // Refresh the visibility of the menu.
-    for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+    for (int i = 0; i < MAX_BDM_TRUE_DEVICES; i++) {
         // Register the device structure into the UI.
         initSupport(&bdmDeviceList[i], i, 0);
 
@@ -882,6 +1027,11 @@ void bdmInitDevicesData()
         // If bdm support is set to manual then only make the first page visible.
         if (bdmDeviceList[i].owner != NULL) {
             opl_io_module_t *pOwner = (opl_io_module_t *)bdmDeviceList[i].owner;
+            bdm_device_data_t *pDeviceData = (bdm_device_data_t *)bdmDeviceList[i].priv;
+            if (!pDeviceData) {
+                pOwner->menuItem.visible = 0;
+                continue;
+            }
 
             if (gBDMStartMode == START_MODE_DISABLED) {
                 pOwner->menuItem.visible = 0;
@@ -890,12 +1040,12 @@ void bdmInitDevicesData()
                 // according to device state.
                 if (bdmDeviceModeStarted == 1) {
                     pOwner->menuItem.visible = 0;
-                    ((bdm_device_data_t *)bdmDeviceList[i].priv)->bdmDeviceTick = -1;
+                    pDeviceData->bdmDeviceTick = -1;
                 } else
                     pOwner->menuItem.visible = (i == 0 ? 1 : 0);
             } else if (gBDMStartMode == START_MODE_AUTO) {
                 pOwner->menuItem.visible = 0;
-                ((bdm_device_data_t *)bdmDeviceList[i].priv)->bdmDeviceTick = -1;
+                pDeviceData->bdmDeviceTick = -1;
             }
 
             LOG("bdmInitDevicesData: setting device %d %s\n", i, (pOwner->menuItem.visible != 0 ? "visible" : "invisible"));
@@ -923,7 +1073,7 @@ void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData)
     pDeviceData->bdmHddIsLBA48 = fileXioDevctl("xhdd0:", ATA_DEVCTL_IS_48BIT, NULL, 0, NULL, 0);
     if (pDeviceData->bdmHddIsLBA48 < 0) {
         // Failed to query the LBA limit of the device, fail safe to LBA28.
-        LOG("Mass device %d is backed by ATA but failed to get LBA limit %d\n", pDeviceData->massDeviceIndex, pDeviceData->bdmHddIsLBA48);
+        LOG("BDM device %d is backed by ATA but failed to get LBA limit %d\n", pDeviceData->massDeviceIndex, pDeviceData->bdmHddIsLBA48);
         pDeviceData->bdmHddIsLBA48 = 0;
     }
 
@@ -931,7 +1081,7 @@ void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData)
     pDeviceData->ataHighestUDMAMode = fileXioDevctl("xhdd0:", ATA_DEVCTL_GET_HIGHEST_UDMA_MODE, NULL, 0, NULL, 0);
     if (pDeviceData->ataHighestUDMAMode < 0 || pDeviceData->ataHighestUDMAMode > 7) {
         // Failed to query highest UDMA mode supported.
-        LOG("Mass device %d is backed by ATA but failed to get highest UDMA mode %d\n", pDeviceData->ataHighestUDMAMode);
+        LOG("BDM device %d is backed by ATA but failed to get highest UDMA mode %d\n", pDeviceData->massDeviceIndex, pDeviceData->ataHighestUDMAMode);
         pDeviceData->ataHighestUDMAMode = 4;
     }
 
@@ -939,9 +1089,282 @@ void bdmResolveLBA_UDMA(bdm_device_data_t *pDeviceData)
     hddSetTransferMode(0x40, pDeviceData->ataHighestUDMAMode);
 }
 
+static const char *bdmGetDevicePrefix(int deviceType)
+{
+    switch (deviceType) {
+        case BDM_TYPE_USB:
+            return "usb";
+        case BDM_TYPE_ILINK:
+            return "ilink";
+        case BDM_TYPE_SDC:
+            return "mx4sio";
+        case BDM_TYPE_ATA:
+            return "ata";
+        default:
+            return NULL;
+    }
+}
+
+static int bdmBuildTruePath(char *path, size_t pathSize, int deviceType, int deviceIndex, int withSlash)
+{
+    const char *prefix = bdmGetDevicePrefix(deviceType);
+    int len;
+
+    if (!path || !pathSize || !prefix || deviceIndex < 0)
+        return 0;
+
+    if (withSlash)
+        len = snprintf(path, pathSize, "%s%d:/", prefix, deviceIndex);
+    else
+        len = snprintf(path, pathSize, "%s%d:", prefix, deviceIndex);
+
+    if (len < 0 || (size_t)len >= pathSize) {
+        path[0] = '\0';
+        return 0;
+    }
+
+    return 1;
+}
+
+static int bdmOpenTrueDevice(int deviceType, int deviceIndex)
+{
+    char path[16];
+
+    if (!bdmBuildTruePath(path, sizeof(path), deviceType, deviceIndex, 1))
+        return -1;
+
+    return fileXioDopen(path);
+}
+
+static int bdmParseLegacyMassPath(const char *path, int *index, const char **tail)
+{
+    const char *p;
+    int value;
+
+    if (!path || strncmp(path, "mass", 4))
+        return 0;
+
+    p = path + 4;
+    value = -1;
+
+    // wLE seems to use mass: instead of mass0:
+    if (*p != ':') {
+        if (*p < '0' || *p > '9')
+            return 0;
+
+        value = 0;
+
+        while (*p >= '0' && *p <= '9') {
+            value = value * 10 + (*p - '0');
+            p++;
+        }
+    }
+
+    if (*p != ':')
+        return 0;
+
+    if (index)
+        *index = value;
+
+    if (tail)
+        *tail = p + 1;
+
+    return 1;
+}
+
+static int bdmSetDeviceTypeAndTruePrefix(bdm_device_data_t *pDeviceData, item_list_t *itemList, int deviceType, int deviceIndex)
+{
+    if (!pDeviceData)
+        return BDM_TYPE_UNKNOWN;
+
+    pDeviceData->bdmDeviceType = deviceType;
+
+    if (!bdmBuildTruePath(pDeviceData->bdmTruePrefix, sizeof(pDeviceData->bdmTruePrefix), deviceType, deviceIndex, 0)) {
+        pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
+        pDeviceData->bdmTruePrefix[0] = '\0';
+        return BDM_TYPE_UNKNOWN;
+    }
+
+    if (itemList)
+        itemList->flags = deviceType == BDM_TYPE_ATA ? MODE_FLAG_COMPAT_DMA : 0;
+
+    return pDeviceData->bdmDeviceType;
+}
+
+static int bdmSetupDeviceData(bdm_device_data_t *pDeviceData, item_list_t *itemList, int deviceType, int deviceIndex, int dir)
+{
+    if (!pDeviceData || dir < 0)
+        return 0;
+
+    memset(pDeviceData->bdmDriver, 0, sizeof(pDeviceData->bdmDriver));
+    pDeviceData->bdmTruePrefix[0] = '\0';
+    pDeviceData->bdmPrefix[0] = '\0';
+    pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
+    pDeviceData->massDeviceIndex = deviceIndex;
+
+    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &pDeviceData->bdmDriver, sizeof(pDeviceData->bdmDriver) - 1);
+    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &pDeviceData->massDeviceIndex, sizeof(pDeviceData->massDeviceIndex));
+
+    if (itemList)
+        itemList->flags = 0;
+
+    if (bdmSetDeviceTypeAndTruePrefix(pDeviceData, itemList, deviceType, pDeviceData->massDeviceIndex) == BDM_TYPE_UNKNOWN)
+        return 0;
+
+    if (gBDMPrefix[0] != '\0')
+        snprintf(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), "%s%s/", pDeviceData->bdmTruePrefix, gBDMPrefix);
+    else
+        snprintf(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), "%s", pDeviceData->bdmTruePrefix);
+
+    return 1;
+}
+
+int bdmResolveLegacyPath(char *out, size_t out_len, const char *path)
+{
+    char massPath[16];
+    char truePrefix[16];
+    char driver[32];
+    const char *tail;
+    int massIndex;
+    int deviceIndex;
+    int deviceType;
+    int dir;
+    int len;
+
+    if (!out || !out_len || !path)
+        return 0;
+
+    if (!bdmParseLegacyMassPath(path, &massIndex, &tail))
+        return 0;
+
+    if (massIndex >= 0)
+        len = snprintf(massPath, sizeof(massPath), "mass%d:/", massIndex);
+    else
+        len = snprintf(massPath, sizeof(massPath), "mass:/");
+
+    if (len < 0 || (size_t)len >= sizeof(massPath))
+        return 0;
+
+    dir = fileXioDopen(massPath);
+    if (dir < 0) {
+        LOG("BDMSUPPORT: failed to open legacy path root '%s'\n", massPath);
+        return 0;
+    }
+
+    memset(driver, 0, sizeof(driver));
+    deviceIndex = massIndex >= 0 ? massIndex : 0;
+
+    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, driver, sizeof(driver) - 1);
+    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &deviceIndex, sizeof(deviceIndex));
+
+    fileXioDclose(dir);
+
+    if (!strcmp(driver, "usb"))
+        deviceType = BDM_TYPE_USB;
+    else if (!strcmp(driver, "sdc") && strlen(driver) == 3)
+        deviceType = BDM_TYPE_SDC;
+    else if (!strcmp(driver, "sd") && strlen(driver) == 2)
+        deviceType = BDM_TYPE_ILINK;
+    else if (!strcmp(driver, "ata") && strlen(driver) == 3)
+        deviceType = BDM_TYPE_ATA;
+    else
+        return 0;
+
+    if (!bdmBuildTruePath(truePrefix, sizeof(truePrefix), deviceType, deviceIndex, 0))
+        return 0;
+
+    len = snprintf(out, out_len, "%s%s", truePrefix, tail);
+    if (len < 0 || (size_t)len >= out_len) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    LOG("BDMSUPPORT: resolved legacy path '%s' -> '%s'\n", path, out);
+
+    return 1;
+}
+
+static int bdmBuildResolvedLegacyCandidate(char *out, size_t out_len, const char *truePrefix, const char *tail)
+{
+    int len;
+
+    if (!out || !out_len || !truePrefix || !truePrefix[0])
+        return 0;
+
+    if (tail && tail[0])
+        len = snprintf(out, out_len, "%s%s", truePrefix, tail);
+    else
+        len = snprintf(out, out_len, "%s/", truePrefix);
+
+    if (len < 0 || (size_t)len >= out_len) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    return 1;
+}
+
+static int bdmResolveLegacyPathFromDeviceListPass(char *out, size_t out_len, const char *tail, int massIndex, int strictIndex)
+{
+    int i;
+    struct stat st;
+
+    if (!bdmDeviceListInitialized)
+        return 0;
+
+    for (i = 0; i < MAX_BDM_TRUE_DEVICES; i++) {
+        bdm_device_data_t *pDeviceData = bdmDeviceList[i].priv;
+        char candidate[128];
+
+        if (!pDeviceData || !pDeviceData->bdmTruePrefix[0])
+            continue;
+
+        if (strictIndex && massIndex >= 0 && pDeviceData->massDeviceIndex != massIndex)
+            continue;
+
+        if (!bdmBuildResolvedLegacyCandidate(candidate, sizeof(candidate), pDeviceData->bdmTruePrefix, tail))
+            continue;
+
+        if (stat(candidate, &st) != 0)
+            continue;
+
+        snprintf(out, out_len, "%s", candidate);
+        LOG("BDMSUPPORT: resolved legacy path from device list '%s'\n", out);
+
+        return 1;
+    }
+
+    return 0;
+}
+
+int bdmResolveLegacyPathFromDeviceList(char *out, size_t out_len, const char *path)
+{
+    const char *tail;
+    int massIndex;
+
+    if (!out || !out_len || !path)
+        return 0;
+
+    if (!bdmParseLegacyMassPath(path, &massIndex, &tail))
+        return 0;
+
+    // First try a strict match using the reported BDM device number
+    if (bdmResolveLegacyPathFromDeviceListPass(out, out_len, tail, massIndex, 1))
+        return 1;
+
+    // Fallback wLE massN: does not always match the true BDM index
+    if (bdmResolveLegacyPathFromDeviceListPass(out, out_len, tail, massIndex, 0))
+        return 1;
+
+    LOG("BDMSUPPORT: could not resolve legacy path from device list '%s'\n", path);
+
+    return 0;
+}
+
 int bdmUpdateDeviceData(item_list_t *itemList)
 {
-    char path[16] = {0};
+    int deviceType;
+    int deviceIndex;
 
     // If bdm mode is disabled bail out as we don't want to update the visibility state of the device pages.
     if (gBDMStartMode == START_MODE_DISABLED)
@@ -951,45 +1374,54 @@ int bdmUpdateDeviceData(item_list_t *itemList)
 
     // Get the per-device data and check if the menu item is currently visible.
     bdm_device_data_t *pDeviceData = itemList->priv;
+    if (!pDeviceData)
+        return 0;
+
     int visible = itemList->owner != NULL ? ((opl_io_module_t *)itemList->owner)->menuItem.visible : 0;
 
-    // Format the device path and try to open the device.
-    sprintf(path, "mass%d:/", itemList->mode);
-    int dir = fileXioDopen(path);
+    deviceIndex = itemList->mode % MAX_BDM_DEVICES;
+
+    switch (itemList->mode / MAX_BDM_DEVICES) {
+        case 0:
+            deviceType = BDM_TYPE_USB;
+            break;
+        case 1:
+            deviceType = BDM_TYPE_ILINK;
+            break;
+        case 2:
+            deviceType = BDM_TYPE_SDC;
+            break;
+        case 3:
+            deviceType = BDM_TYPE_ATA;
+            break;
+        default:
+            return 0;
+    }
+
+    // Try to open the device by its real BDM prefix.
+    int dir = bdmOpenTrueDevice(deviceType, deviceIndex);
     // LOG("opendir %s -> %d\n", path, dir);
 
     // If we opened the device and the menu isn't visible (OR is visible but hasn't been initialized ex: manual device start) initialize device info.
     if (dir >= 0 && (visible == 0 || pDeviceData->bdmPrefix[0] == '\0')) {
-        if (gBDMPrefix[0] != '\0')
-            snprintf(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), "mass%d:%s/", itemList->mode, gBDMPrefix);
-        else
-            snprintf(pDeviceData->bdmPrefix, sizeof(pDeviceData->bdmPrefix), "mass%d:", itemList->mode);
+        int hadDevice = pDeviceData->bdmTruePrefix[0] != '\0' || pDeviceData->bdmPrefix[0] != '\0';
+        int oldDeviceType = pDeviceData->bdmDeviceType;
+        int oldMassDeviceIndex = pDeviceData->massDeviceIndex;
+        char oldTruePrefix[sizeof(pDeviceData->bdmTruePrefix)];
 
-        // Get the name of the underlying device driver that backs the fat fs.
-        fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &pDeviceData->bdmDriver, sizeof(pDeviceData->bdmDriver) - 1);
-        fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &pDeviceData->massDeviceIndex, sizeof(pDeviceData->massDeviceIndex));
+        snprintf(oldTruePrefix, sizeof(oldTruePrefix), "%s", pDeviceData->bdmTruePrefix);
 
-        itemList->flags = 0;
-
-        // Determine the bdm device type based on the underlying device driver.
-        if (!strcmp(pDeviceData->bdmDriver, "usb"))
-            pDeviceData->bdmDeviceType = BDM_TYPE_USB;
-        else if (!strcmp(pDeviceData->bdmDriver, "sd") && strlen(pDeviceData->bdmDriver) == 2)
-            pDeviceData->bdmDeviceType = BDM_TYPE_ILINK;
-        else if (!strcmp(pDeviceData->bdmDriver, "sdc") && strlen(pDeviceData->bdmDriver) == 3)
-            pDeviceData->bdmDeviceType = BDM_TYPE_SDC;
-        else if (!strcmp(pDeviceData->bdmDriver, "ata") && strlen(pDeviceData->bdmDriver) == 3) {
-            pDeviceData->bdmDeviceType = BDM_TYPE_ATA;
-            itemList->flags = MODE_FLAG_COMPAT_DMA;
-        } else
-            pDeviceData->bdmDeviceType = BDM_TYPE_UNKNOWN;
+        if (!bdmSetupDeviceData(pDeviceData, itemList, deviceType, deviceIndex, dir)) {
+            fileXioDclose(dir);
+            return 0;
+        }
 
         // If the device is backed by the ATA driver then get the supported LBA size for the drive.
         if (pDeviceData->bdmDeviceType == BDM_TYPE_ATA) {
             bdmResolveLBA_UDMA(pDeviceData);
-            LOG("Mass device: %d (%d LBA%d UDMA%d) %s -> %s\n", itemList->mode, pDeviceData->massDeviceIndex, (pDeviceData->bdmHddIsLBA48 == 1 ? 48 : 28), pDeviceData->ataHighestUDMAMode, pDeviceData->bdmPrefix, pDeviceData->bdmDriver);
+            LOG("BDM device: %d (%d LBA%d UDMA%d) %s -> %s\n", itemList->mode, pDeviceData->massDeviceIndex, (pDeviceData->bdmHddIsLBA48 == 1 ? 48 : 28), pDeviceData->ataHighestUDMAMode, pDeviceData->bdmPrefix, pDeviceData->bdmDriver);
         } else
-            LOG("Mass device: %d (%d) %s -> %s\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDriver);
+            LOG("BDM device: %d (%d) %s -> %s\n", itemList->mode, pDeviceData->massDeviceIndex, pDeviceData->bdmPrefix, pDeviceData->bdmDriver);
 
         // Make the menu item visible.
         if (itemList->owner != NULL) {
@@ -999,17 +1431,38 @@ int bdmUpdateDeviceData(item_list_t *itemList)
 
         // Close the device handle.
         fileXioDclose(dir);
-        return 1;
+
+        if (!hadDevice)
+            return 1;
+
+        if (oldDeviceType != pDeviceData->bdmDeviceType)
+            return 1;
+
+        if (oldMassDeviceIndex != pDeviceData->massDeviceIndex)
+            return 1;
+
+        if (strcmp(oldTruePrefix, pDeviceData->bdmTruePrefix))
+            return 1;
+
+        return 0;
     } else if (dir < 0 && visible == 1) {
+        int hadDevice = pDeviceData->bdmTruePrefix[0] != '\0';
+
         // Device has been removed, make the menu item invisible. We can't really cleanup resources (like the game list) just yet
         // as we don't know if the data is being used asynchronously.
+        pDeviceData->bdmTruePrefix[0] = '\0';
+        pDeviceData->bdmPrefix[0] = '\0';
         if (itemList->owner != NULL) {
             LOG("bdmUpdateDeviceData: setting device %d invisible\n", itemList->mode);
             ((opl_io_module_t *)itemList->owner)->menuItem.visible = 0;
         }
 
-        LOG("Mass device: %d (%d) disconnected\n", itemList->mode, pDeviceData->massDeviceIndex);
-        return -1;
+        if (hadDevice) {
+            LOG("BDM device: %d (%d) disconnected\n", itemList->mode, pDeviceData->massDeviceIndex);
+            return -1;
+        }
+
+        return 0;
     }
 
     // No change to the device state detected.
@@ -1020,11 +1473,14 @@ int bdmUpdateDeviceData(item_list_t *itemList)
 
 void autoLaunchBDMGame(char *argv[])
 {
-    char path[256];
-
     miniInit(BDM_MODE);
 
     gAutoLaunchBDMGame = malloc(sizeof(base_game_info_t));
+    if (!gAutoLaunchBDMGame) {
+        miniDeinit();
+        return;
+    }
+
     memset(gAutoLaunchBDMGame, 0, sizeof(base_game_info_t));
 
     int nameLen;
@@ -1052,46 +1508,79 @@ void autoLaunchBDMGame(char *argv[])
     gAutoLaunchBDMGame->parts = 1; // ul not supported.
 
     gAutoLaunchDeviceData = malloc(sizeof(bdm_device_data_t));
-    memset(gAutoLaunchDeviceData, 0, sizeof(bdm_device_data_t));
+    if (!gAutoLaunchDeviceData) {
+        miniDeinit();
 
-    char apaDevicePrefix[8] = {0};
-    delay(8);
-    snprintf(apaDevicePrefix, sizeof(apaDevicePrefix), "mass0:");
-    // Loop through mass0: to mass4:
-    for (int i = 0; i <= 4; i++) {
-        snprintf(path, sizeof(path), "mass%d:", i);
-        int dir = fileXioDopen(path);
+        free(gAutoLaunchBDMGame);
+        gAutoLaunchBDMGame = NULL;
 
-        if (dir >= 0) {
-            fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &gAutoLaunchDeviceData->bdmDriver, sizeof(gAutoLaunchDeviceData->bdmDriver) - 1);
-            fileXioIoctl2(dir, USBMASS_IOCTL_GET_DEVICE_NUMBER, NULL, 0, &gAutoLaunchDeviceData->massDeviceIndex, sizeof(gAutoLaunchDeviceData->massDeviceIndex));
-
-            if (!strcmp(gAutoLaunchDeviceData->bdmDriver, "ata") && strlen(gAutoLaunchDeviceData->bdmDriver) == 3) {
-                bdmResolveLBA_UDMA(gAutoLaunchDeviceData);
-                snprintf(apaDevicePrefix, sizeof(apaDevicePrefix), "mass%d:", i);
-                fileXioDclose(dir);
-                break; // Exit the loop if "ata" device is found
-            }
-
-            fileXioDclose(dir);
-        } else {
-            // Retry for mass0: only
-            if (i == 0) {
-                delay(6);
-                i--;
-            } else {
-                break;
-            }
-        }
-        delay(6);
+        return;
     }
 
-    if (gBDMPrefix[0] != '\0') {
-        snprintf(path, sizeof(path), "%s%s/CFG/%s.cfg", apaDevicePrefix, gBDMPrefix, gAutoLaunchBDMGame->startup);
-        snprintf(gAutoLaunchDeviceData->bdmPrefix, sizeof(gAutoLaunchDeviceData->bdmPrefix), "%s%s/", apaDevicePrefix, gBDMPrefix);
-    } else {
-        snprintf(path, sizeof(path), "%sCFG/%s.cfg", apaDevicePrefix, gAutoLaunchBDMGame->startup);
-        snprintf(gAutoLaunchDeviceData->bdmPrefix, sizeof(gAutoLaunchDeviceData->bdmPrefix), "%s", apaDevicePrefix);
+    memset(gAutoLaunchDeviceData, 0, sizeof(bdm_device_data_t));
+
+    int foundDevice = 0;
+
+    delay(8);
+
+    // Probe real BDM prefixes only.
+    for (int typeSlot = 0; typeSlot < 4; typeSlot++) {
+        int deviceType;
+
+        switch (typeSlot) {
+            case 0:
+                deviceType = BDM_TYPE_USB;
+                break;
+            case 1:
+                deviceType = BDM_TYPE_ILINK;
+                break;
+            case 2:
+                deviceType = BDM_TYPE_SDC;
+                break;
+            case 3:
+                deviceType = BDM_TYPE_ATA;
+                break;
+            default:
+                continue;
+        }
+
+        for (int i = 0; i < MAX_BDM_DEVICES; i++) {
+            bdm_device_data_t candidateData;
+            int dir = bdmOpenTrueDevice(deviceType, i);
+
+            if (dir >= 0) {
+                memset(&candidateData, 0, sizeof(candidateData));
+                bdmSetupDeviceData(&candidateData, NULL, deviceType, i, dir);
+
+                if (candidateData.bdmDeviceType != BDM_TYPE_UNKNOWN && (!foundDevice || candidateData.bdmDeviceType == BDM_TYPE_ATA)) {
+                    memcpy(gAutoLaunchDeviceData, &candidateData, sizeof(bdm_device_data_t));
+                    foundDevice = 1;
+                }
+
+                if (candidateData.bdmDeviceType == BDM_TYPE_ATA) {
+                    bdmResolveLBA_UDMA(gAutoLaunchDeviceData);
+                    fileXioDclose(dir);
+                    break; // Exit the loop if "ata" device is found
+                }
+
+                fileXioDclose(dir);
+            } else
+                break;
+
+            delay(6);
+        }
+    }
+
+    if (!foundDevice) {
+        miniDeinit();
+
+        free(gAutoLaunchBDMGame);
+        gAutoLaunchBDMGame = NULL;
+
+        free(gAutoLaunchDeviceData);
+        gAutoLaunchDeviceData = NULL;
+
+        return;
     }
 
     per_game_cfg_t pgcfg;
@@ -1100,61 +1589,21 @@ void autoLaunchBDMGame(char *argv[])
     bdmLaunchGame(NULL, -1, &pgcfg);
 }
 
-static int bdmWaitForDevice(int deviceId, u32 timeoutMs)
-{
-    const int RETRY_DELAY = 100;
-    char path[16];
-
-    u32 start = GetTimerSystemTime();
-    sprintf(path, "mass%d:/", deviceId);
-
-    while (1) {
-        int dir = fileXioDopen(path);
-
-        if (dir >= 0) {
-            fileXioDclose(dir);
-            return 1; // ready
-        }
-
-        u32 now = GetTimerSystemTime();
-        u32 elapsed_ms = (now - start) / (kBUSCLK / 1000);
-
-        if (elapsed_ms > timeoutMs) {
-            return 0; // timeout
-        }
-
-        DelayThread(RETRY_DELAY * 1000);
-    }
-}
-
-static int bdmDeviceIsPresent(int deviceId)
-{
-    char path[16];
-    sprintf(path, "mass%d:/", deviceId);
-    int dir = fileXioDopen(path);
-
-    if (dir >= 0) {
-        fileXioDclose(dir);
-        return 1; // ready
-    }
-
-    return 0;
-}
-
 static int bdmDeviceIsATA(int deviceId)
 {
-    char path[16];
     bdm_device_data_t data;
 
-    sprintf(path, "mass%d:/", deviceId);
-    int dir = fileXioDopen(path);
+    int dir = bdmOpenTrueDevice(BDM_TYPE_ATA, deviceId);
+
     if (dir < 0)
         return 0;
 
-    fileXioIoctl2(dir, USBMASS_IOCTL_GET_DRIVERNAME, NULL, 0, &data.bdmDriver, sizeof(data.bdmDriver) - 1);
+    memset(&data, 0, sizeof(data));
+    bdmSetupDeviceData(&data, NULL, BDM_TYPE_ATA, deviceId, dir);
+
     fileXioDclose(dir);
 
-    return (!strcmp(data.bdmDriver, "ata") && strlen(data.bdmDriver) == 3);
+    return data.bdmDeviceType == BDM_TYPE_ATA;
 }
 
 static int bdmGetATADeviceId()

--- a/src/config_wopl.c
+++ b/src/config_wopl.c
@@ -360,26 +360,6 @@ static void sanitize_pad_sensitivity(void)
         gYSensitivity = 0;
 }
 
-static int config_path_has_device_prefix(const char *path, const char *prefix)
-{
-    size_t len;
-
-    if (!path || !prefix)
-        return 0;
-
-    len = strlen(prefix);
-
-    if (strncmp(path, prefix, len))
-        return 0;
-
-    path += len;
-
-    while (*path >= '0' && *path <= '9')
-        path++;
-
-    return *path == ':';
-}
-
 static void prepare_config_root_modules(const char *path)
 {
     if (!path || !path[0])
@@ -389,7 +369,7 @@ static void prepare_config_root_modules(const char *path)
     bdmLoadModulesForPath(path);
 
     // APA/PFS internal HDD root: hddN:
-    if (config_path_has_device_prefix(path, "hdd")) {
+    if (pathHasDevicePrefix(path, "hdd")) {
         guiSetBootStatusIfActive("Loading HDD config root...");
         LOG("CONFIG: loading HDD modules for config root '%s'\n", path);
         hddLoadModules();
@@ -398,7 +378,7 @@ static void prepare_config_root_modules(const char *path)
     }
 
     // MMCE root: mmceN:
-    if (config_path_has_device_prefix(path, "mmce")) {
+    if (pathHasDevicePrefix(path, "mmce")) {
         guiSetBootStatusIfActive("Loading MMCE config root...");
         LOG("CONFIG: loading MMCE modules for config root '%s'\n", path);
         mmceLoadModules();
@@ -427,25 +407,25 @@ static int wait_for_config_root_ready(const char *path)
     return 0;
 }
 
-static int normalise_true_config_dir(char *out, size_t out_len, const char *dir, int allowLegacyMass)
+static int normalise_config_root_dir(char *out, size_t out_len, const char *dir, int allowUsbMassCompat)
 {
-    int legacyLaunchPath;
+    int usbMassCompatPath;
 
     if (!out || !out_len || !dir || !dir[0]) {
         LOG("CONFIG: normalise failed invalid dir='%s'\n", dir ? dir : "(null)");
         return 0;
     }
 
-    legacyLaunchPath = pathIsLegacyMassPath(dir);
+    usbMassCompatPath = pathIsUsbMassCompatPath(dir);
 
-    if (legacyLaunchPath) {
-        if (!allowLegacyMass) {
-            LOG("CONFIG: rejecting legacy mass path '%s'\n", dir);
+    if (usbMassCompatPath) {
+        if (!allowUsbMassCompat) {
+            LOG("CONFIG: rejecting USB mass compatibility path '%s'\n", dir);
             return 0;
         }
 
-        guiSetBootStatusIfActive("Loading legacy mass support...");
-        bdmLoadModulesForLegacyMass();
+        guiSetBootStatusIfActive("Loading USB mass compatibility support...");
+        bdmLoadModulesForUsbMassCompat();
 
         delay(8);
 
@@ -455,14 +435,8 @@ static int normalise_true_config_dir(char *out, size_t out_len, const char *dir,
         LOG("CONFIG: using legacy launch config dir '%s'\n", out);
 
         return 1;
-    } else {
-        if (!pathResolveToTrue(out, out_len, dir)) {
-            LOG("CONFIG: failed to resolve true config dir '%s'\n", dir);
-            return 0;
-        }
-
-        LOG("CONFIG: resolved true config dir '%s' -> '%s'\n", dir, out);
-    }
+    } else
+        copy_str(out, dir, out_len);
 
     pathNormaliseDir(out, out_len);
 
@@ -493,18 +467,16 @@ static int load_boot_config_from_dir(const char *launch_dir)
     const char *value;
     config_t cfg;
     int have_config_dir = 0;
-    int legacy_boot_root = 0;
 
     if (!launch_dir || !launch_dir[0])
         return 0;
 
     // Prepare the boot/cwd root before trying to read wopl_boot.cfg from it
     // Legacy massN: is allowed here only because this path came from argv0/cwd
-    if (!normalise_true_config_dir(boot_root, sizeof(boot_root), launch_dir, 1))
+    if (!normalise_config_root_dir(boot_root, sizeof(boot_root), launch_dir, 1))
         return 0;
 
     copy_str(boot_dir, boot_root, sizeof(boot_dir));
-    legacy_boot_root = pathIsLegacyMassPath(boot_root);
 
     if (!pathJoin(boot_path, sizeof(boot_path), boot_root, BOOT_FILENAME)) {
         LOG("CONFIG: failed to build boot cfg path from '%s'\n", boot_root);
@@ -530,10 +502,10 @@ static int load_boot_config_from_dir(const char *launch_dir)
     cfgValidateBegin(boot_path);
 
     if (cfgGetStr(&cfg, "boot.config_dir", &value) && value[0]) {
-        // boot.config_dir is user selected config root.. Do not accept legacy massN: here
-        if (pathIsLegacyMassPath(value)) {
+        // boot.config_dir is user selected config root.. do not accept USB mass compatibility paths here
+        if (pathIsUsbMassCompatPath(value)) {
             LOG("CONFIG: ignoring legacy boot.config_dir '%s'\n", value);
-        } else if (normalise_true_config_dir(resolved_dir, sizeof(resolved_dir), value, 0)) {
+        } else if (normalise_config_root_dir(resolved_dir, sizeof(resolved_dir), value, 0)) {
             copy_str(config_dir, resolved_dir, sizeof(config_dir));
             have_config_dir = 1;
         } else
@@ -563,7 +535,7 @@ static int pick_default_config_dir(void)
         if (load_boot_config_from_dir(dir))
             return 1;
 
-        if (normalise_true_config_dir(true_dir, sizeof(true_dir), dir, 1)) {
+        if (normalise_config_root_dir(true_dir, sizeof(true_dir), dir, 1)) {
             copy_str(boot_dir, true_dir, sizeof(boot_dir));
             copy_str(config_dir, true_dir, sizeof(config_dir));
             LOG("CONFIG: using boot/cwd config_dir='%s'\n", config_dir);
@@ -587,22 +559,10 @@ static int pick_default_config_dir(void)
 
 static int ensure_config_dir(void)
 {
-    const char *launch;
-    char cwd[128];
-    int ok;
-
     if (config_dir[0])
         return 1;
 
-    launch = pathGetLaunchPath();
-
-    cwd[0] = '\0';
-    if (getcwd(cwd, sizeof(cwd)) == NULL)
-        copy_str(cwd, "(getcwd failed)", sizeof(cwd));
-
-    ok = pick_default_config_dir();
-
-    return ok;
+    return pick_default_config_dir();
 }
 
 static int do_save_at_dir(const char *dir, const char *filename, void (*build)(config_setting_t *))
@@ -665,12 +625,12 @@ static int save_boot_config(void)
     if (!boot_dir[0] || !config_dir[0])
         return 1;
 
-    if (pathIsLegacyMassPath(config_dir)) {
+    if (pathIsUsbMassCompatPath(config_dir)) {
         LOG("CONFIG: not saving unresolved legacy boot config_dir '%s'\n", config_dir);
         return 1;
     }
 
-    if (config_path_has_device_prefix(boot_dir, "mc") && !sbEnsureMCConfigFolder(boot_dir)) {
+    if (pathHasDevicePrefix(boot_dir, "mc") && !sbEnsureMCConfigFolder(boot_dir)) {
         LOG("CONFIG: failed to prepare MC boot folder '%s'\n", boot_dir);
         return 0;
     }
@@ -1721,47 +1681,40 @@ void configApply(int themeID, int langID, int skipDeviceRefresh)
 #endif
 }
 
-static int resolve_legacy_config_paths(void)
+static int resolve_usb_mass_config_path(char *dir, size_t dir_len, const char *label)
 {
     char resolved[128];
 
-    if (pathIsLegacyMassPath(config_dir)) {
-        LOG("CONFIG: resolving legacy config_dir '%s'\n", config_dir);
+    if (!pathIsUsbMassCompatPath(dir))
+        return 1;
 
-        if (!bdmResolveLegacyPath(resolved, sizeof(resolved), config_dir)) {
-            LOG("CONFIG: could not resolve legacy config_dir '%s'\n", config_dir);
-            return 0;
-        }
+    LOG("CONFIG: resolving USB mass compatibility %s '%s'\n", label, dir);
 
-        pathNormaliseDir(resolved, sizeof(resolved));
-
-        if (!pathIsDevicePath(resolved) || pathIsLegacyMassPath(resolved)) {
-            LOG("CONFIG: rejected resolved config_dir '%s'\n", resolved);
-            return 0;
-        }
-
-        LOG("CONFIG: resolved config_dir '%s' -> '%s'\n", config_dir, resolved);
-        copy_str(config_dir, resolved, sizeof(config_dir));
+    if (!bdmResolveUsbMassCompatPath(resolved, sizeof(resolved), dir)) {
+        LOG("CONFIG: could not resolve USB mass compatibility %s '%s'\n", label, dir);
+        return 0;
     }
 
-    if (pathIsLegacyMassPath(boot_dir)) {
-        LOG("CONFIG: resolving legacy boot_dir '%s'\n", boot_dir);
+    pathNormaliseDir(resolved, sizeof(resolved));
 
-        if (!bdmResolveLegacyPath(resolved, sizeof(resolved), boot_dir)) {
-            LOG("CONFIG: could not resolve legacy boot_dir '%s'\n", boot_dir);
-            return 0;
-        }
-
-        pathNormaliseDir(resolved, sizeof(resolved));
-
-        if (!pathIsDevicePath(resolved) || pathIsLegacyMassPath(resolved)) {
-            LOG("CONFIG: rejected resolved boot_dir '%s'\n", resolved);
-            return 0;
-        }
-
-        LOG("CONFIG: resolved boot_dir '%s' -> '%s'\n", boot_dir, resolved);
-        copy_str(boot_dir, resolved, sizeof(boot_dir));
+    if (!pathIsDevicePath(resolved) || pathIsUsbMassCompatPath(resolved)) {
+        LOG("CONFIG: rejected resolved %s '%s'\n", label, resolved);
+        return 0;
     }
+
+    LOG("CONFIG: resolved %s '%s' -> '%s'\n", label, dir, resolved);
+    copy_str(dir, resolved, dir_len);
+
+    return 1;
+}
+
+static int resolve_usb_mass_config_paths(void)
+{
+    if (!resolve_usb_mass_config_path(config_dir, sizeof(config_dir), "config_dir"))
+        return 0;
+
+    if (!resolve_usb_mass_config_path(boot_dir, sizeof(boot_dir), "boot_dir"))
+        return 0;
 
     return 1;
 }
@@ -1795,7 +1748,7 @@ void _loadConfig() // called directly by initializer at boot before GUI is ready
     LOG("CONFIG: load requested=0x%X result=0x%X config_dir='%s'\n", lscstatus, result, config_dir);
 
     configApply(themeID, langID, 0);
-    resolve_legacy_config_paths();
+    resolve_usb_mass_config_paths();
 
     lscret = result;
     lscstatus = 0;
@@ -1842,12 +1795,12 @@ static int save_all_to_current_dir(int types) // like the old configWriteMulti()
         return 0;
     }
 
-    if (!resolve_legacy_config_paths())
+    if (!resolve_usb_mass_config_paths())
         return 0;
 
     LOG("CONFIG: saving to config_dir '%s'\n", config_dir);
 
-    if (config_path_has_device_prefix(config_dir, "mc") && !sbEnsureMCConfigFolder(config_dir)) {
+    if (pathHasDevicePrefix(config_dir, "mc") && !sbEnsureMCConfigFolder(config_dir)) {
         LOG("CONFIG: failed to prepare MC config folder '%s'\n", config_dir);
         return 0;
     }

--- a/src/config_wopl.c
+++ b/src/config_wopl.c
@@ -19,8 +19,10 @@
 #include "include/supportbase.h"
 #include "include/bdmsupport.h"
 #include "include/hddsupport.h"
+#include "include/mmcesupport.h"
 #include "include/config_migration.h" // DELETE_WITH_MIGRATION
 #include "include/module.h"
+#include "include/pathsupport.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -52,8 +54,10 @@
 #define GAME_FILENAME_OLD "conf_game.cfg" // DELETE_WITH_MIGRATION
 
 #define LAST_FILENAME "wopl_last_played.cfg"
+#define BOOT_FILENAME "wopl_boot.cfg"
 
 static char config_dir[128] = {0};
+static char boot_dir[128] = {0};
 static char last_played[256] = {0};
 
 static char s_theme_name[128] = {0};
@@ -352,161 +356,260 @@ static void sanitize_pad_sensitivity(void)
 {
     if (gXSensitivity < 0 || gXSensitivity > 2)
         gXSensitivity = 0;
-
     if (gYSensitivity < 0 || gYSensitivity > 2)
         gYSensitivity = 0;
 }
 
+static int config_path_has_device_prefix(const char *path, const char *prefix)
+{
+    size_t len;
+
+    if (!path || !prefix)
+        return 0;
+
+    len = strlen(prefix);
+
+    if (strncmp(path, prefix, len))
+        return 0;
+
+    path += len;
+
+    while (*path >= '0' && *path <= '9')
+        path++;
+
+    return *path == ':';
+}
+
+static void prepare_config_root_modules(const char *path)
+{
+    if (!path || !path[0])
+        return;
+
+    // BDM/FAT roots: usbN:, mx4sioN:, ilinkN:, ataN:
+    bdmLoadModulesForPath(path);
+
+    // APA/PFS internal HDD root: hddN:
+    if (config_path_has_device_prefix(path, "hdd")) {
+        guiSetBootStatusIfActive("Loading HDD config root...");
+        LOG("CONFIG: loading HDD modules for config root '%s'\n", path);
+        hddLoadModules();
+        hddLoadSupportModules();
+        return;
+    }
+
+    // MMCE root: mmceN:
+    if (config_path_has_device_prefix(path, "mmce")) {
+        guiSetBootStatusIfActive("Loading MMCE config root...");
+        LOG("CONFIG: loading MMCE modules for config root '%s'\n", path);
+        mmceLoadModules();
+        return;
+    }
+}
+
+#define CONFIG_ROOT_READY_RETRIES 10
+#define CONFIG_ROOT_READY_DELAY   3
+
+static int wait_for_config_root_ready(const char *path)
+{
+    int i;
+
+    for (i = 0; i < CONFIG_ROOT_READY_RETRIES; i++) {
+        if (path_exists(path)) {
+            if (i > 0)
+                LOG("CONFIG: config root ready after %d retries '%s'\n", i, path);
+
+            return 1;
+        }
+
+        delay(CONFIG_ROOT_READY_DELAY);
+    }
+
+    return 0;
+}
+
+static int normalise_true_config_dir(char *out, size_t out_len, const char *dir, int allowLegacyMass)
+{
+    int legacyLaunchPath;
+
+    if (!out || !out_len || !dir || !dir[0]) {
+        LOG("CONFIG: normalise failed invalid dir='%s'\n", dir ? dir : "(null)");
+        return 0;
+    }
+
+    legacyLaunchPath = pathIsLegacyMassPath(dir);
+
+    LOG("CONFIG: normalise dir='%s' allowLegacyMass=%d legacy=%d\n", dir, allowLegacyMass, legacyLaunchPath);
+
+    if (legacyLaunchPath) {
+        if (!allowLegacyMass) {
+            LOG("CONFIG: rejecting legacy mass path '%s'\n", dir);
+            return 0;
+        }
+
+        guiSetBootStatusIfActive("Loading legacy mass support...");
+        bdmLoadModulesForLegacyMass();
+
+        delay(8);
+
+        copy_str(out, dir, out_len);
+        pathNormaliseDir(out, out_len);
+
+        LOG("CONFIG: using legacy launch config dir '%s'\n", out);
+
+        return 1;
+    } else {
+        if (!pathResolveToTrue(out, out_len, dir)) {
+            LOG("CONFIG: failed to resolve true config dir '%s'\n", dir);
+            return 0;
+        }
+
+        LOG("CONFIG: resolved true config dir '%s' -> '%s'\n", dir, out);
+    }
+
+    pathNormaliseDir(out, out_len);
+
+    LOG("CONFIG: normalised config dir='%s'\n", out);
+
+    if (!pathIsDevicePath(out)) {
+        LOG("CONFIG: rejected non-device config dir '%s'\n", out);
+        return 0;
+    }
+
+    // Load only the modules required by this selected boot/config root before probing it.
+    prepare_config_root_modules(out);
+
+    // BDM modules may be loaded but the filesystem/device might not be ready..
+    if (!wait_for_config_root_ready(out)) {
+        LOG("CONFIG: config root not ready '%s'\n", out);
+        return 0;
+    }
+
+    LOG("CONFIG: config root ready '%s'\n", out);
+
+    return 1;
+}
+
+static int load_boot_config_from_dir(const char *launch_dir)
+{
+    char boot_root[128];
+    char boot_path[256];
+    char resolved_dir[128];
+    const char *value;
+    config_t cfg;
+    int have_config_dir = 0;
+    int legacy_boot_root = 0;
+
+    if (!launch_dir || !launch_dir[0])
+        return 0;
+
+    // Prepare the boot/cwd root before trying to read wopl_boot.cfg from it
+    // Legacy massN: is allowed here only because this path came from argv0/cwd
+    if (!normalise_true_config_dir(boot_root, sizeof(boot_root), launch_dir, 1))
+        return 0;
+
+    copy_str(boot_dir, boot_root, sizeof(boot_dir));
+    legacy_boot_root = pathIsLegacyMassPath(boot_root);
+
+    if (!pathJoin(boot_path, sizeof(boot_path), boot_root, BOOT_FILENAME)) {
+        LOG("CONFIG: failed to build boot cfg path from '%s'\n", boot_root);
+        return 0;
+    }
+
+    LOG("CONFIG: boot root='%s' boot cfg='%s'\n", boot_root, boot_path);
+
+    if (!file_exists(boot_path)) {
+        LOG("CONFIG: no boot cfg at '%s', using boot root\n", boot_path);
+        copy_str(config_dir, boot_root, sizeof(config_dir));
+        return 1;
+    }
+
+    config_init(&cfg);
+
+    if (!config_read_file(&cfg, boot_path)) {
+        log_config_error(boot_path, &cfg);
+        config_destroy(&cfg);
+        return 0;
+    }
+
+    cfgValidateBegin(boot_path);
+
+    if (!legacy_boot_root && cfgGetStr(&cfg, "boot.config_dir", &value)) {
+        // boot.config_dir is user selected config root.. Do not accept legacy massN: here
+        if (normalise_true_config_dir(resolved_dir, sizeof(resolved_dir), value, 0)) {
+            copy_str(config_dir, resolved_dir, sizeof(config_dir));
+            have_config_dir = 1;
+        } else
+            LOG("CONFIG: ignoring invalid boot.config_dir '%s'\n", value);
+    } else if (legacy_boot_root)
+        LOG("CONFIG: ignoring boot.config_dir while using legacy launch root '%s'\n", boot_root);
+
+    if (!have_config_dir) {
+        copy_str(config_dir, boot_root, sizeof(config_dir));
+        have_config_dir = 1;
+    }
+
+    cfgValidateEnd();
+    config_destroy(&cfg);
+
+    LOG("CONFIG: boot config '%s' config_dir='%s'\n", boot_path, config_dir);
+
+    return have_config_dir;
+}
+
 static int pick_default_config_dir(void)
 {
-    int mc = sysCheckMC();
-
-    // like old tryAlternateDevice().. first launch no config prefers mc..
-    if (mc >= 0) {
-        snprintf(config_dir, sizeof(config_dir), "mc%d:%s/", mc & 1, WOPL_CONFIG_NAME);
-        return 1;
-    }
-
-    // no mc? old logic tried mass0 next..
-    DIR *dir = opendir("mass0:/");
-    if (dir != NULL) {
-        closedir(dir);
-        copy_str(config_dir, "mass0:/", sizeof(config_dir));
-        return 1;
-    }
-
-    // last fallback is HDD..
-    if (gHDDPrefix && gHDDPrefix[0] && path_exists(gHDDPrefix)) {
-        copy_str(config_dir, gHDDPrefix, sizeof(config_dir));
-        return 1;
-    }
-
-    return 0;
-}
-
-static int probe_bdm_config_path(const char *filename, char *dir_out, size_t dir_len, char *path_out, size_t path_len, int for_write)
-{
-    char dir[64];
-    int result;
-
-    result = bdmFindPartition(dir, filename, for_write);
-    if (result == 0) {
-        if (hddLoadModules() >= 0 && bdmHDDIsPresent(5000))
-            result = bdmFindPartition(dir, filename, for_write);
-    }
-
-    if (!result)
-        return 0;
-
-    copy_str(dir_out, dir, dir_len);
-    snprintf(path_out, path_len, "%s%s", dir, filename);
-
-    return 1;
-}
-
-static int probe_hdd_config_path(const char *filename, char *dir_out, size_t dir_len, char *path_out, size_t path_len, int for_write)
-{
-    if (!gHDDPrefix || !gHDDPrefix[0])
-        return 0;
-
-    hddLoadModules();
-
-    if (for_write) {
-        if (hddCheck() != 0)
-            return 0;
-    } else
-        hddLoadSupportModules();
-
-    snprintf(path_out, path_len, "%s%s", gHDDPrefix, filename);
-
-    if (!for_write && !file_exists(path_out))
-        return 0;
-
-    copy_str(dir_out, gHDDPrefix, dir_len);
-
-    return 1;
-}
-
-static int probe_boot_config_path(const char *filename, char *dir_out, size_t dir_len, char *path_out, size_t path_len, int for_write)
-{
-    char pwd[8];
-
-    getcwd(pwd, sizeof(pwd));
-
-    if (!strncmp(pwd, "mass", 4) && (pwd[4] == ':' || pwd[5] == ':'))
-        return probe_bdm_config_path(filename, dir_out, dir_len, path_out, path_len, for_write);
-
-    if (!strncmp(pwd, "hdd", 3) && (pwd[3] == ':' || pwd[4] == ':'))
-        return probe_hdd_config_path(filename, dir_out, dir_len, path_out, path_len, for_write);
-
-    return 0;
-}
-
-static int probe_config_path(const char *filename, char *dir_out, size_t dir_len, char *path_out, size_t path_len, int for_write)
-{
     char dir[128];
-    char path[256];
+    char true_dir[128];
+    int mc;
 
-    // 1. current/default location mc..
-    int mc = sysCheckMC();
-    if (mc >= 0) {
-        snprintf(dir, sizeof(dir), "mc%d:%s/", mc & 1, WOPL_CONFIG_NAME);
-        snprintf(path, sizeof(path), "%s%s", dir, filename);
+    if (pathGetBootDir(dir, sizeof(dir))) {
+        if (load_boot_config_from_dir(dir))
+            return 1;
 
-        if (for_write || file_exists(path)) {
-            copy_str(dir_out, dir, dir_len);
-            copy_str(path_out, path, path_len);
+        if (normalise_true_config_dir(true_dir, sizeof(true_dir), dir, 1)) {
+            copy_str(boot_dir, true_dir, sizeof(boot_dir));
+            copy_str(config_dir, true_dir, sizeof(config_dir));
+            LOG("CONFIG: using boot/cwd config_dir='%s'\n", config_dir);
             return 1;
         }
     }
 
-    // 2. first try the device OPL booted from..
-    if (probe_boot_config_path(filename, dir_out, dir_len, path_out, path_len, for_write))
-        return 1;
+    // Fallback only if no usable boot/cwd root exists
+    // Prefer the MC slot that already has the wOPL config folder
+    mc = sbCheckMC();
 
-    // 3. then try BDM..
-    if (probe_bdm_config_path(filename, dir_out, dir_len, path_out, path_len, for_write))
+    if (mc >= 0) {
+        snprintf(config_dir, sizeof(config_dir), "mc%c:%s/", mc, WOPL_CONFIG_NAME);
+        copy_str(boot_dir, config_dir, sizeof(boot_dir));
+        LOG("CONFIG: falling back to MC config_dir='%s'\n", config_dir);
         return 1;
-
-    // 4. then try HDD..
-    if (probe_hdd_config_path(filename, dir_out, dir_len, path_out, path_len, for_write))
-        return 1;
+    }
 
     return 0;
 }
 
-static int ensure_mc_dir(const char *dir)
-{
-    struct stat st;
-    if (stat(dir, &st) == 0)
-        return 1;
-
-    return mkdir(dir, 0777) == 0 || errno == EEXIST;
-}
-
 static int ensure_config_dir(void)
 {
-    char dir[128];
-    char path[256];
+    const char *launch;
+    char cwd[128];
+    int ok;
 
     if (config_dir[0])
         return 1;
 
-    if (
-        probe_config_path(WOPL_FILENAME, dir, sizeof(dir), path, sizeof(path), 0) ||
-        probe_config_path(NET_FILENAME, dir, sizeof(dir), path, sizeof(path), 0) ||
-        probe_config_path(GAME_FILENAME, dir, sizeof(dir), path, sizeof(path), 0) ||
-        // DELETE_WITH_MIGRATION
-        probe_config_path(WOPL_FILENAME_OLD, dir, sizeof(dir), path, sizeof(path), 0) ||
-        probe_config_path(NET_FILENAME_OLD, dir, sizeof(dir), path, sizeof(path), 0) ||
-        probe_config_path(GAME_FILENAME_OLD, dir, sizeof(dir), path, sizeof(path), 0)
-        // DELETE_WITH_MIGRATION
-    ) {
-        copy_str(config_dir, dir, sizeof(config_dir));
-        return 1;
-    }
+    launch = pathGetLaunchPath();
 
-    return pick_default_config_dir();
+    cwd[0] = '\0';
+    if (getcwd(cwd, sizeof(cwd)) == NULL)
+        copy_str(cwd, "(getcwd failed)", sizeof(cwd));
+
+    LOG("CONFIG: ensure_config_dir launch='%s' cwd='%s'\n", launch ? launch : "(null)", cwd);
+
+    ok = pick_default_config_dir();
+
+    LOG("CONFIG: ensure_config_dir result=%d config_dir='%s' boot_dir='%s'\n", ok, config_dir, boot_dir);
+
+    return ok;
 }
 
 static int do_save_at_dir(const char *dir, const char *filename, void (*build)(config_setting_t *))
@@ -516,21 +619,8 @@ static int do_save_at_dir(const char *dir, const char *filename, void (*build)(c
     if (!dir || !dir[0])
         return 0;
 
-    snprintf(path, sizeof(path), "%s%s", dir, filename);
-
-    if (!strncmp(dir, "mc", 2)) {
-        char mc_dir[128];
-        copy_str(mc_dir, dir, sizeof(mc_dir));
-        size_t len = strlen(mc_dir);
-
-        if (len > 0 && mc_dir[len - 1] == '/')
-            mc_dir[len - 1] = '\0';
-
-        if (!ensure_mc_dir(mc_dir)) {
-            LOG("CONFIG: failed to create MC dir '%s'\n", mc_dir);
-            return 0;
-        }
-    }
+    if (!pathJoin(path, sizeof(path), dir, filename))
+        return 0;
 
     config_t cfg;
     config_init(&cfg);
@@ -558,6 +648,58 @@ static int do_save(const char *filename, void (*build)(config_setting_t *))
         return 0;
 
     return do_save_at_dir(config_dir, filename, build);
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap config (wopl_boot.cfg)
+// ---------------------------------------------------------------------------
+
+static void build_boot(config_setting_t *root)
+{
+    config_setting_t *group;
+
+    group = add_group(root, "boot");
+    set_str(group, "config_dir", config_dir);
+}
+
+static int save_boot_config(void)
+{
+    char path[256];
+    config_t cfg;
+    config_setting_t *root;
+    int ok;
+
+    if (!boot_dir[0] || !config_dir[0])
+        return 1;
+
+    if (pathIsLegacyMassPath(config_dir)) {
+        LOG("CONFIG: not saving unresolved legacy boot config_dir '%s'\n", config_dir);
+        return 1;
+    }
+
+    if (config_path_has_device_prefix(boot_dir, "mc") && !sbEnsureMCConfigFolder(boot_dir)) {
+        LOG("CONFIG: failed to prepare MC boot folder '%s'\n", boot_dir);
+        return 0;
+    }
+
+    if (!pathJoin(path, sizeof(path), boot_dir, BOOT_FILENAME))
+        return 0;
+
+    config_init(&cfg);
+    root = config_root_setting(&cfg);
+    build_boot(root);
+
+    ok = config_write_file(&cfg, path);
+    config_destroy(&cfg);
+
+    if (!ok) {
+        LOG("CONFIG: failed to write boot config '%s'\n", path);
+        return 0;
+    }
+
+    LOG("CONFIG: saved boot config '%s'\n", path);
+
+    return 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -678,6 +820,7 @@ static void parse_devices(config_t *cfg)
 static void parse_paths(config_t *cfg)
 {
     const char *path;
+
     if ((path = lookup_str(cfg, "paths.bdm_prefix", NULL)))
         copy_str(gBDMPrefix, path, sizeof(gBDMPrefix));
 
@@ -839,8 +982,8 @@ static void parse_opl_cfg(config_t *cfg, int *out_theme_id, int *out_lang_id)
 
 int wOPLLoad(int *out_theme_id, int *out_lang_id)
 {
-    char dir[128];
     char path[256];
+    char old_path[256];
     config_t cfg;
 
     if (out_theme_id)
@@ -848,53 +991,64 @@ int wOPLLoad(int *out_theme_id, int *out_lang_id)
     if (out_lang_id)
         *out_lang_id = 0;
 
+    LOG("CONFIG_WOPL: enter config_dir='%s'\n", config_dir);
+
+    if (!ensure_config_dir())
+        return 0;
+
     // 1. Try new filename
-    if (probe_config_path(WOPL_FILENAME, dir, sizeof(dir), path, sizeof(path), 0)) {
-        config_init(&cfg);
-        if (config_read_file(&cfg, path)) {
-            cfgValidateBegin(path);
-            parse_opl_cfg(&cfg, out_theme_id, out_lang_id);
-            cfgValidateEnd();
-            config_destroy(&cfg);
-            copy_str(config_dir, dir, sizeof(config_dir));
-            LOG("CONFIG_WOPL: loaded from '%s'\n", path);
-            return 1;
-        }
-        log_config_error(path, &cfg);
-        config_destroy(&cfg);
-    }
+    if (!pathJoin(path, sizeof(path), config_dir, WOPL_FILENAME))
+        return 0;
 
-    // DELETE_WITH_MIGRATION
-    // 2. Try old filename.. migrate to new filename and delete old
-    if (probe_config_path(WOPL_FILENAME_OLD, dir, sizeof(dir), path, sizeof(path), 0)) {
-        int ok = 0;
-        config_init(&cfg);
-        if (config_read_file(&cfg, path) && config_lookup(&cfg, "display") != NULL) {
-            parse_opl_cfg(&cfg, out_theme_id, out_lang_id);
-            ok = 1;
-        }
+    LOG("CONFIG_WOPL: trying '%s'\n", path);
+
+    config_init(&cfg);
+    if (config_read_file(&cfg, path)) {
+        cfgValidateBegin(path);
+        parse_opl_cfg(&cfg, out_theme_id, out_lang_id);
+        cfgValidateEnd();
         config_destroy(&cfg);
 
-        if (!ok) {
-            LOG("CONFIG_WOPL: old format detected, attempting legacy migration\n");
-            ok = cfgMigrateLegacyOPL(path, out_theme_id, out_lang_id);
-        }
-
-        if (!ok)
-            return 0;
-
-        copy_str(config_dir, dir, sizeof(config_dir));
-        if (wOPLSave()) {
-            char bak[256];
-            snprintf(bak, sizeof(bak), "%s.bak", path);
-            rename(path, bak);
-            LOG("CONFIG_WOPL: migrated to '%s'\n", WOPL_FILENAME);
-        }
+        LOG("CONFIG_WOPL: loaded from '%s'\n", path);
         return 1;
     }
-    // DELETE_WITH_MIGRATION
 
-    return 0;
+    LOG("CONFIG_WOPL: failed new config '%s'\n", path);
+    log_config_error(path, &cfg);
+    config_destroy(&cfg);
+
+    // DELETE_WITH_MIGRATION
+    // 2. Try old filename from the selected config root only.
+    if (!pathJoin(old_path, sizeof(old_path), config_dir, WOPL_FILENAME_OLD))
+        return 0;
+
+    config_init(&cfg);
+    int ok = 0;
+
+    if (config_read_file(&cfg, old_path) && config_lookup(&cfg, "display") != NULL) {
+        parse_opl_cfg(&cfg, out_theme_id, out_lang_id);
+        ok = 1;
+    }
+    config_destroy(&cfg);
+
+    if (!ok) {
+        LOG("CONFIG_WOPL: old format detected at selected config root, attempting legacy migration\n");
+        ok = cfgMigrateLegacyOPL(old_path, out_theme_id, out_lang_id);
+    }
+
+    if (!ok)
+        return 0;
+
+    if (wOPLSave()) {
+        char bak[256];
+
+        snprintf(bak, sizeof(bak), "%s.bak", old_path);
+        rename(old_path, bak);
+        LOG("CONFIG_WOPL: migrated to '%s'\n", WOPL_FILENAME);
+    }
+
+    return 1;
+    // DELETE_WITH_MIGRATION
 }
 
 int wOPLSave(void)
@@ -968,6 +1122,8 @@ static void build_net(config_setting_t *root)
 
 int wOPLNetLoad(void)
 {
+    LOG("CONFIG_NET: enter config_dir='%s'\n", config_dir);
+
     if (!ensure_config_dir())
         return 0;
 
@@ -975,8 +1131,12 @@ int wOPLNetLoad(void)
     char old_path[256];
     config_t cfg;
 
+    if (!pathJoin(path, sizeof(path), config_dir, NET_FILENAME))
+        return 0;
+
+    LOG("CONFIG_NET: trying '%s'\n", path);
+
     // 1. Try new filename
-    snprintf(path, sizeof(path), "%s%s", config_dir, NET_FILENAME);
     config_init(&cfg);
     if (config_read_file(&cfg, path)) {
         cfgValidateBegin(path);
@@ -991,7 +1151,9 @@ int wOPLNetLoad(void)
 
     // DELETE_WITH_MIGRATION
     // 2. Try old filename.. migrate to new filename and delete old
-    snprintf(old_path, sizeof(old_path), "%s%s", config_dir, NET_FILENAME_OLD);
+    if (!pathJoin(old_path, sizeof(old_path), config_dir, NET_FILENAME_OLD))
+        return 0;
+
     config_init(&cfg);
     int ok = 0;
     if (config_read_file(&cfg, old_path) && config_lookup(&cfg, "ps2") != NULL) {
@@ -1035,7 +1197,9 @@ int wOPLLastLoad(void)
         return 0;
 
     char path[256];
-    snprintf(path, sizeof(path), "%s%s", config_dir, LAST_FILENAME);
+
+    if (!pathJoin(path, sizeof(path), config_dir, LAST_FILENAME))
+        return 0;
 
     config_t cfg;
     config_init(&cfg);
@@ -1063,7 +1227,9 @@ int wOPLLastSave(const char *startup)
         return 0;
 
     char path[256];
-    snprintf(path, sizeof(path), "%s%s", config_dir, LAST_FILENAME);
+
+    if (!pathJoin(path, sizeof(path), config_dir, LAST_FILENAME))
+        return 0;
 
     config_t cfg;
     config_init(&cfg);
@@ -1165,13 +1331,19 @@ static void build_global_game(config_setting_t *root)
 
 int wOPLGlobalGameLoad(void)
 {
+    LOG("CONFIG_GAME: enter config_dir='%s'\n", config_dir);
+
     if (!ensure_config_dir())
         return 0;
 
     char path[256];
     config_t cfg;
 
-    snprintf(path, sizeof(path), "%s%s", config_dir, GAME_FILENAME);
+    if (!pathJoin(path, sizeof(path), config_dir, GAME_FILENAME))
+        return 0;
+
+    LOG("CONFIG_GAME: trying '%s'\n", path);
+
     config_init(&cfg);
     if (config_read_file(&cfg, path)) {
         cfgValidateBegin(path);
@@ -1185,7 +1357,9 @@ int wOPLGlobalGameLoad(void)
     config_destroy(&cfg);
 
     // DELETE_WITH_MIGRATION v
-    snprintf(path, sizeof(path), "%s%s", config_dir, GAME_FILENAME_OLD);
+    if (!pathJoin(path, sizeof(path), config_dir, GAME_FILENAME_OLD))
+        return 0;
+
     if (cfgMigrateLegacyGlobalGame(path)) {
         if (wOPLGlobalGameSave()) {
             char bak[256];
@@ -1503,9 +1677,9 @@ int wOPLGameInfoSave(const char *path, const game_info_t *gi)
     return ok;
 }
 
-// ---------------------------------------------------------------------------------------------------------------------------------
-// Application level config handling.. oof i dont like the old logic.. TODO: split devices to seperate cfg change save/load logic
-// ---------------------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Application level config handling
+// ---------------------------------------------------------------------------
 
 char *gBaseMCDir; // used for thm/lang even after migration
 
@@ -1538,12 +1712,12 @@ void configApply(int themeID, int langID, int skipDeviceRefresh)
 
     // Check if we should refresh device support as well.
     if (skipDeviceRefresh == 0) {
-        initAllSupport(0);
+        bdmLoadEnabledDeviceModules();
 
+        initAllSupport(0);
         for (int i = 0; i < MODE_COUNT; i++) {
             if (list_support[i].support == NULL)
                 continue;
-
             moduleUpdateMenuInternal(&list_support[i], changed, langChanged);
         }
     } else {
@@ -1560,10 +1734,42 @@ void configApply(int themeID, int langID, int skipDeviceRefresh)
 #endif
 }
 
+static int resolve_legacy_config_dir(void)
+{
+    char resolved[128];
+
+    if (!pathIsLegacyMassPath(config_dir))
+        return 1;
+
+    LOG("CONFIG: resolving legacy config_dir '%s'\n", config_dir);
+
+    if (!bdmResolveLegacyPathFromDeviceList(resolved, sizeof(resolved), config_dir)) {
+        LOG("CONFIG: could not resolve legacy config_dir '%s'\n", config_dir);
+        return 0;
+    }
+
+    pathNormaliseDir(resolved, sizeof(resolved));
+
+    if (!pathIsDevicePath(resolved) || pathIsLegacyMassPath(resolved)) {
+        LOG("CONFIG: rejected resolved config_dir '%s'\n", resolved);
+        return 0;
+    }
+
+    LOG("CONFIG: resolved config_dir '%s' -> '%s'\n", config_dir, resolved);
+    copy_str(config_dir, resolved, sizeof(config_dir));
+
+    return 1;
+}
+
 void _loadConfig() // called directly by initializer at boot before GUI is ready
 {
     int themeID = -1, langID = -1;
     int result = 0;
+    int have_config_dir;
+
+    have_config_dir = ensure_config_dir();
+
+    LOG("CONFIG: initial config root result=%d config_dir='%s' boot_dir='%s'\n", have_config_dir, config_dir, boot_dir);
 
     if (lscstatus & CONFIG_OPL) {
         if (wOPLLoad(&themeID, &langID))
@@ -1581,7 +1787,11 @@ void _loadConfig() // called directly by initializer at boot before GUI is ready
         if (wOPLGlobalGameLoad())
             result |= CONFIG_GAME;
 
+    LOG("CONFIG: load requested=0x%X result=0x%X config_dir='%s'\n", lscstatus, result, config_dir);
+
     configApply(themeID, langID, 0);
+    resolve_legacy_config_dir();
+
     lscret = result;
     lscstatus = 0;
     if (result)
@@ -1620,13 +1830,22 @@ static int config_type_count(int types)
 static int save_all_to_current_dir(int types) // like the old configWriteMulti()
 {
     int result = 0;
+    int expected = config_type_count(types);
 
-    if (!ensure_config_dir())
+    if (!ensure_config_dir()) {
+        LOG("CONFIG: no config_dir selected for save\n");
+        return 0;
+    }
+
+    if (!resolve_legacy_config_dir())
         return 0;
 
-    const char *path = wOPLGetDir();
-    if (path && !strncmp(path, "mc", 2))
-        sbCheckMCFolder();
+    LOG("CONFIG: saving to config_dir '%s'\n", config_dir);
+
+    if (config_path_has_device_prefix(config_dir, "mc") && !sbEnsureMCConfigFolder(config_dir)) {
+        LOG("CONFIG: failed to prepare MC config folder '%s'\n", config_dir);
+        return 0;
+    }
 
     if (types & CONFIG_OPL)
         result += do_save_at_dir(config_dir, WOPL_FILENAME, build_opl);
@@ -1635,145 +1854,18 @@ static int save_all_to_current_dir(int types) // like the old configWriteMulti()
     if (types & CONFIG_GAME)
         result += do_save_at_dir(config_dir, GAME_FILENAME, build_global_game);
 
-    return result;
-}
+    if (result != expected)
+        return result;
 
-static int save_all_to_dir(const char *dir, int types)
-{
-    int result = 0;
-    char target_dir[128];
-
-    if (!dir || !dir[0])
+    if (!save_boot_config())
         return 0;
 
-    copy_str(target_dir, dir, sizeof(target_dir));
-
-    if (!strncmp(target_dir, "mc", 2))
-        sbCheckMCFolder();
-
-    if (types & CONFIG_OPL)
-        result += do_save_at_dir(target_dir, WOPL_FILENAME, build_opl);
-    if (types & CONFIG_NETWORK)
-        result += do_save_at_dir(target_dir, NET_FILENAME, build_net);
-    if (types & CONFIG_GAME)
-        result += do_save_at_dir(target_dir, GAME_FILENAME, build_global_game);
-
     return result;
-}
-
-static int try_save_all_boot(int types)
-{
-    char dir[128];
-    char path[256];
-
-    if (types & CONFIG_OPL) {
-        if (probe_boot_config_path(WOPL_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    if (types & CONFIG_NETWORK) {
-        if (probe_boot_config_path(NET_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    if (types & CONFIG_GAME) {
-        if (probe_boot_config_path(GAME_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    return 0;
-}
-
-static int try_save_all_mc(int types)
-{
-    int mc = sysCheckMC();
-
-    if (mc < 0)
-        return 0;
-
-    char dir[128];
-    snprintf(dir, sizeof(dir), "mc%d:%s/", mc & 1, WOPL_CONFIG_NAME);
-
-    return save_all_to_dir(dir, types);
-}
-
-static int try_save_all_bdm(int types)
-{
-    char dir[128];
-    char path[256];
-
-    if (types & CONFIG_OPL) {
-        if (probe_bdm_config_path(WOPL_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    if (types & CONFIG_NETWORK) {
-        if (probe_bdm_config_path(NET_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    if (types & CONFIG_GAME) {
-        if (probe_bdm_config_path(GAME_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    return 0;
-}
-
-static int try_save_all_hdd(int types)
-{
-    char dir[128];
-    char path[256];
-
-    if (types & CONFIG_OPL) {
-        if (probe_hdd_config_path(WOPL_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    if (types & CONFIG_NETWORK) {
-        if (probe_hdd_config_path(NET_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    if (types & CONFIG_GAME) {
-        if (probe_hdd_config_path(GAME_FILENAME, dir, sizeof(dir), path, sizeof(path), 1))
-            return save_all_to_dir(dir, types);
-    }
-
-    return 0;
-}
-
-static int save_all_with_fallback(int types)
-{
-    int result;
-    int expected = config_type_count(types);
-
-    result = save_all_to_current_dir(types);
-    if (result == expected)
-        return result;
-
-    result = try_save_all_boot(types);
-    if (result == expected)
-        return result;
-
-    result = try_save_all_mc(types);
-    if (result == expected)
-        return result;
-
-    result = try_save_all_bdm(types);
-    if (result == expected)
-        return result;
-
-    result = try_save_all_hdd(types);
-    if (result == expected)
-        return result;
-
-    return 0;
 }
 
 static void _saveConfig()
 {
-    lscret = save_all_with_fallback(lscstatus);
+    lscret = save_all_to_current_dir(lscstatus);
     lscstatus = 0;
 }
 

--- a/src/config_wopl.c
+++ b/src/config_wopl.c
@@ -438,8 +438,6 @@ static int normalise_true_config_dir(char *out, size_t out_len, const char *dir,
 
     legacyLaunchPath = pathIsLegacyMassPath(dir);
 
-    LOG("CONFIG: normalise dir='%s' allowLegacyMass=%d legacy=%d\n", dir, allowLegacyMass, legacyLaunchPath);
-
     if (legacyLaunchPath) {
         if (!allowLegacyMass) {
             LOG("CONFIG: rejecting legacy mass path '%s'\n", dir);
@@ -467,8 +465,6 @@ static int normalise_true_config_dir(char *out, size_t out_len, const char *dir,
     }
 
     pathNormaliseDir(out, out_len);
-
-    LOG("CONFIG: normalised config dir='%s'\n", out);
 
     if (!pathIsDevicePath(out)) {
         LOG("CONFIG: rejected non-device config dir '%s'\n", out);
@@ -533,15 +529,16 @@ static int load_boot_config_from_dir(const char *launch_dir)
 
     cfgValidateBegin(boot_path);
 
-    if (!legacy_boot_root && cfgGetStr(&cfg, "boot.config_dir", &value)) {
+    if (cfgGetStr(&cfg, "boot.config_dir", &value) && value[0]) {
         // boot.config_dir is user selected config root.. Do not accept legacy massN: here
-        if (normalise_true_config_dir(resolved_dir, sizeof(resolved_dir), value, 0)) {
+        if (pathIsLegacyMassPath(value)) {
+            LOG("CONFIG: ignoring legacy boot.config_dir '%s'\n", value);
+        } else if (normalise_true_config_dir(resolved_dir, sizeof(resolved_dir), value, 0)) {
             copy_str(config_dir, resolved_dir, sizeof(config_dir));
             have_config_dir = 1;
         } else
             LOG("CONFIG: ignoring invalid boot.config_dir '%s'\n", value);
-    } else if (legacy_boot_root)
-        LOG("CONFIG: ignoring boot.config_dir while using legacy launch root '%s'\n", boot_root);
+    }
 
     if (!have_config_dir) {
         copy_str(config_dir, boot_root, sizeof(config_dir));
@@ -603,11 +600,7 @@ static int ensure_config_dir(void)
     if (getcwd(cwd, sizeof(cwd)) == NULL)
         copy_str(cwd, "(getcwd failed)", sizeof(cwd));
 
-    LOG("CONFIG: ensure_config_dir launch='%s' cwd='%s'\n", launch ? launch : "(null)", cwd);
-
     ok = pick_default_config_dir();
-
-    LOG("CONFIG: ensure_config_dir result=%d config_dir='%s' boot_dir='%s'\n", ok, config_dir, boot_dir);
 
     return ok;
 }
@@ -1000,8 +993,6 @@ int wOPLLoad(int *out_theme_id, int *out_lang_id)
     if (!pathJoin(path, sizeof(path), config_dir, WOPL_FILENAME))
         return 0;
 
-    LOG("CONFIG_WOPL: trying '%s'\n", path);
-
     config_init(&cfg);
     if (config_read_file(&cfg, path)) {
         cfgValidateBegin(path);
@@ -1133,8 +1124,6 @@ int wOPLNetLoad(void)
 
     if (!pathJoin(path, sizeof(path), config_dir, NET_FILENAME))
         return 0;
-
-    LOG("CONFIG_NET: trying '%s'\n", path);
 
     // 1. Try new filename
     config_init(&cfg);
@@ -1341,8 +1330,6 @@ int wOPLGlobalGameLoad(void)
 
     if (!pathJoin(path, sizeof(path), config_dir, GAME_FILENAME))
         return 0;
-
-    LOG("CONFIG_GAME: trying '%s'\n", path);
 
     config_init(&cfg);
     if (config_read_file(&cfg, path)) {
@@ -1734,29 +1721,47 @@ void configApply(int themeID, int langID, int skipDeviceRefresh)
 #endif
 }
 
-static int resolve_legacy_config_dir(void)
+static int resolve_legacy_config_paths(void)
 {
     char resolved[128];
 
-    if (!pathIsLegacyMassPath(config_dir))
-        return 1;
+    if (pathIsLegacyMassPath(config_dir)) {
+        LOG("CONFIG: resolving legacy config_dir '%s'\n", config_dir);
 
-    LOG("CONFIG: resolving legacy config_dir '%s'\n", config_dir);
+        if (!bdmResolveLegacyPath(resolved, sizeof(resolved), config_dir)) {
+            LOG("CONFIG: could not resolve legacy config_dir '%s'\n", config_dir);
+            return 0;
+        }
 
-    if (!bdmResolveLegacyPathFromDeviceList(resolved, sizeof(resolved), config_dir)) {
-        LOG("CONFIG: could not resolve legacy config_dir '%s'\n", config_dir);
-        return 0;
+        pathNormaliseDir(resolved, sizeof(resolved));
+
+        if (!pathIsDevicePath(resolved) || pathIsLegacyMassPath(resolved)) {
+            LOG("CONFIG: rejected resolved config_dir '%s'\n", resolved);
+            return 0;
+        }
+
+        LOG("CONFIG: resolved config_dir '%s' -> '%s'\n", config_dir, resolved);
+        copy_str(config_dir, resolved, sizeof(config_dir));
     }
 
-    pathNormaliseDir(resolved, sizeof(resolved));
+    if (pathIsLegacyMassPath(boot_dir)) {
+        LOG("CONFIG: resolving legacy boot_dir '%s'\n", boot_dir);
 
-    if (!pathIsDevicePath(resolved) || pathIsLegacyMassPath(resolved)) {
-        LOG("CONFIG: rejected resolved config_dir '%s'\n", resolved);
-        return 0;
+        if (!bdmResolveLegacyPath(resolved, sizeof(resolved), boot_dir)) {
+            LOG("CONFIG: could not resolve legacy boot_dir '%s'\n", boot_dir);
+            return 0;
+        }
+
+        pathNormaliseDir(resolved, sizeof(resolved));
+
+        if (!pathIsDevicePath(resolved) || pathIsLegacyMassPath(resolved)) {
+            LOG("CONFIG: rejected resolved boot_dir '%s'\n", resolved);
+            return 0;
+        }
+
+        LOG("CONFIG: resolved boot_dir '%s' -> '%s'\n", boot_dir, resolved);
+        copy_str(boot_dir, resolved, sizeof(boot_dir));
     }
-
-    LOG("CONFIG: resolved config_dir '%s' -> '%s'\n", config_dir, resolved);
-    copy_str(config_dir, resolved, sizeof(config_dir));
 
     return 1;
 }
@@ -1790,7 +1795,7 @@ void _loadConfig() // called directly by initializer at boot before GUI is ready
     LOG("CONFIG: load requested=0x%X result=0x%X config_dir='%s'\n", lscstatus, result, config_dir);
 
     configApply(themeID, langID, 0);
-    resolve_legacy_config_dir();
+    resolve_legacy_config_paths();
 
     lscret = result;
     lscstatus = 0;
@@ -1837,7 +1842,7 @@ static int save_all_to_current_dir(int types) // like the old configWriteMulti()
         return 0;
     }
 
-    if (!resolve_legacy_config_dir())
+    if (!resolve_legacy_config_paths())
         return 0;
 
     LOG("CONFIG: saving to config_dir '%s'\n", config_dir);

--- a/src/guigame.c
+++ b/src/guigame.c
@@ -1113,7 +1113,7 @@ void guiGameRemoveGlobalSettings(void)
 {
     if (menuCheckParentalLock() == 0) {
         memset(&gGlobalGameCfg, 0, sizeof(gGlobalGameCfg));
-        wOPLGlobalGameSave();
+        configSave(CONFIG_GAME, 0);
     }
 }
 

--- a/src/initializer.c
+++ b/src/initializer.c
@@ -167,7 +167,7 @@ static void setDefaults(void)
     gAutosort = 1;
     gAutoRefresh = 0;
     gEnableDebug = 0;
-    gBDMDebug = 0;
+    gBDMDebug = 1;
     gPS2Logo = 1;
     gHDDGameListCache = 0;
     gEnableWrite = 1;

--- a/src/initializer.c
+++ b/src/initializer.c
@@ -167,7 +167,7 @@ static void setDefaults(void)
     gAutosort = 1;
     gAutoRefresh = 0;
     gEnableDebug = 0;
-    gBDMDebug = 1;
+    gBDMDebug = 0;
     gPS2Logo = 1;
     gHDDGameListCache = 0;
     gEnableWrite = 1;

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,8 @@
 
 #include "include/common.h"
 
+#include "include/pathsupport.h"
+
 #include "include/sound.h"
 #include "include/tetris.h"
 #include "include/xparam.h"
@@ -23,6 +25,7 @@ int main(int argc, char *argv[])
 #endif
 
     LOG_INIT();
+    pathSetLaunchPath(argc > 0 ? argv[0] : NULL);
     PREINIT_LOG("OPL GUI start!\n");
 
     ChangeThreadPriority(GetThreadId(), 31);

--- a/src/menusys.c
+++ b/src/menusys.c
@@ -1047,7 +1047,7 @@ int menuCheckParentalLock(void)
             } else if (strncmp(PARENTAL_LOCK_MASTER_PASS, password, sizeof(password)) == 0) {
                 guiMsgBox(_l(_STR_PARENLOCK_DISABLE_WARNING), 0, NULL);
                 gParentalLockPassword[0] = '\0';
-                wOPLSave();
+                configSave(CONFIG_OPL, 0);
                 result = 0;
                 parentalLockCheckEnabled = 0; // Stop asking for the password.
             } else {
@@ -1384,7 +1384,7 @@ void menuHandleInputGameMenu()
         } else if (menuID == GAME_SAVE_CHANGES) {
             guiGameSaveConfig(&itemPgCfg, selected_item->item->userdata);
             menuSaveConfig();
-            wOPLGlobalGameSave();
+            configSave(CONFIG_GAME, 0);
             guiMsgBox(_l(_STR_GAME_SETTINGS_SAVED), 0, NULL);
             guiGameLoadConfig(selected_item->item->userdata, gameMenuLoadConfig(NULL));
         } else if (menuID == GAME_TEST_CHANGES) {

--- a/src/mmcesupport.c
+++ b/src/mmcesupport.c
@@ -68,11 +68,20 @@ void mmceSetPrefix(void)
 
 void mmceLoadModules(void)
 {
+    static int mmceModulesLoaded = 0;
+
+    if (mmceModulesLoaded)
+        return;
+
     LOG("MMCESUPPORT LoadModules\n");
+
     guiSetBootStatusIfActive("Loading MMCE modules...");
 
     LOG("[MMCEMAN]:\n");
+
     sysLoadModuleBuffer(&mmceman_irx, size_mmceman_irx, 0, NULL);
+
+    mmceModulesLoaded = 1;
 }
 
 void mmceInit(item_list_t *itemList)

--- a/src/pathsupport.c
+++ b/src/pathsupport.c
@@ -1,0 +1,171 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "include/pathsupport.h"
+
+static char launchPath[256];
+
+static void copy_str(char *dst, const char *src, size_t size)
+{
+    if (!size)
+        return;
+
+    if (!src)
+        src = "";
+
+    strncpy(dst, src, size - 1);
+    dst[size - 1] = '\0';
+}
+
+static int path_starts_with_device(const char *path, const char *device)
+{
+    const char *suffix;
+    size_t len;
+
+    if (!path || !device)
+        return 0;
+
+    len = strlen(device);
+
+    if (strncmp(path, device, len))
+        return 0;
+
+    suffix = path + len;
+
+    while (*suffix >= '0' && *suffix <= '9')
+        suffix++;
+
+    return *suffix == ':';
+}
+
+void pathSetLaunchPath(const char *path)
+{
+    copy_str(launchPath, path, sizeof(launchPath));
+}
+
+const char *pathGetLaunchPath(void)
+{
+    return launchPath[0] ? launchPath : NULL;
+}
+
+int pathIsDevicePath(const char *path)
+{
+    static const char *devices[] = {
+        "mc",
+        "usb",
+        "mx4sio",
+        "ilink",
+        "ata",
+        "hdd",
+        "mmce",
+        NULL};
+
+    int i;
+
+    if (!path || !path[0])
+        return 0;
+
+    for (i = 0; devices[i] != NULL; i++) {
+        if (path_starts_with_device(path, devices[i]))
+            return 1;
+    }
+
+    return 0;
+}
+
+void pathNormaliseDir(char *dir, size_t dir_len)
+{
+    size_t len;
+
+    if (!dir_len)
+        return;
+
+    dir[dir_len - 1] = '\0';
+    len = strlen(dir);
+
+    if (len > 0 && dir[len - 1] != '/') {
+        if (len + 1 < dir_len) {
+            dir[len] = '/';
+            dir[len + 1] = '\0';
+        }
+    }
+}
+
+static int path_get_dirname(const char *path, char *dir_out, size_t dir_len)
+{
+    const char *slash;
+
+    if (!path || !path[0] || !dir_len)
+        return 0;
+
+    if (!pathIsDevicePath(path))
+        return 0;
+
+    slash = strrchr(path, '/');
+
+    if (!slash) {
+        copy_str(dir_out, path, dir_len);
+        pathNormaliseDir(dir_out, dir_len);
+        return 1;
+    }
+
+    if ((size_t)(slash - path + 1) >= dir_len)
+        return 0;
+
+    memcpy(dir_out, path, slash - path + 1);
+    dir_out[slash - path + 1] = '\0';
+
+    return 1;
+}
+
+int pathGetBootDir(char *dir_out, size_t dir_len)
+{
+    char pwd[128];
+
+    if (!dir_out || !dir_len)
+        return 0;
+
+    if (path_get_dirname(launchPath, dir_out, dir_len))
+        return 1;
+
+    pwd[0] = '\0';
+
+    if (getcwd(pwd, sizeof(pwd)) == NULL)
+        return 0;
+
+    if (!pathIsDevicePath(pwd))
+        return 0;
+
+    copy_str(dir_out, pwd, dir_len);
+    pathNormaliseDir(dir_out, dir_len);
+
+    return 1;
+}
+
+int pathResolveToTrue(char *out, size_t out_len, const char *path)
+{
+    if (!out || !out_len || !path)
+        return 0;
+
+    copy_str(out, path, out_len);
+
+    return 1;
+}
+
+int pathJoin(char *out, size_t out_len, const char *dir, const char *name)
+{
+    int len;
+
+    if (!out || !out_len || !dir || !dir[0] || !name)
+        return 0;
+
+    len = snprintf(out, out_len, "%s%s", dir, name);
+
+    if (len < 0 || len >= out_len) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    return 1;
+}

--- a/src/pathsupport.c
+++ b/src/pathsupport.c
@@ -74,6 +74,28 @@ int pathIsDevicePath(const char *path)
     return 0;
 }
 
+int pathIsLegacyMassPath(const char *path)
+{
+    const char *p;
+
+    if (!path || strncmp(path, "mass", 4))
+        return 0;
+
+    p = path + 4;
+
+    // wLE seems to use mass: instead of mass0:
+    if (*p == ':')
+        return 1;
+
+    if (*p < '0' || *p > '9')
+        return 0;
+
+    while (*p >= '0' && *p <= '9')
+        p++;
+
+    return *p == ':';
+}
+
 void pathNormaliseDir(char *dir, size_t dir_len)
 {
     size_t len;
@@ -92,14 +114,14 @@ void pathNormaliseDir(char *dir, size_t dir_len)
     }
 }
 
-static int path_get_dirname(const char *path, char *dir_out, size_t dir_len)
+static int path_get_dirname(const char *path, char *dir_out, size_t dir_len, int allowLegacyMass)
 {
     const char *slash;
 
     if (!path || !path[0] || !dir_len)
         return 0;
 
-    if (!pathIsDevicePath(path))
+    if (!pathIsDevicePath(path) && (!allowLegacyMass || !pathIsLegacyMassPath(path)))
         return 0;
 
     slash = strrchr(path, '/');
@@ -126,7 +148,8 @@ int pathGetBootDir(char *dir_out, size_t dir_len)
     if (!dir_out || !dir_len)
         return 0;
 
-    if (path_get_dirname(launchPath, dir_out, dir_len))
+    // argv0/cwd could still be massN: on old launch paths.. accept it only here
+    if (path_get_dirname(launchPath, dir_out, dir_len, 1))
         return 1;
 
     pwd[0] = '\0';
@@ -134,7 +157,7 @@ int pathGetBootDir(char *dir_out, size_t dir_len)
     if (getcwd(pwd, sizeof(pwd)) == NULL)
         return 0;
 
-    if (!pathIsDevicePath(pwd))
+    if (!pathIsDevicePath(pwd) && !pathIsLegacyMassPath(pwd))
         return 0;
 
     copy_str(dir_out, pwd, dir_len);

--- a/src/pathsupport.c
+++ b/src/pathsupport.c
@@ -18,10 +18,11 @@ static void copy_str(char *dst, const char *src, size_t size)
     dst[size - 1] = '\0';
 }
 
-static int path_starts_with_device(const char *path, const char *device)
+int pathParseDevicePrefix(const char *path, const char *device, int *index, const char **tail, int requireIndex)
 {
     const char *suffix;
     size_t len;
+    int value = -1;
 
     if (!path || !device)
         return 0;
@@ -33,10 +34,36 @@ static int path_starts_with_device(const char *path, const char *device)
 
     suffix = path + len;
 
-    while (*suffix >= '0' && *suffix <= '9')
-        suffix++;
+    if (*suffix != ':') {
+        if (*suffix < '0' || *suffix > '9')
+            return 0;
 
-    return *suffix == ':';
+        value = 0;
+
+        while (*suffix >= '0' && *suffix <= '9') {
+            value = value * 10 + (*suffix - '0');
+            suffix++;
+        }
+    }
+
+    if (*suffix != ':')
+        return 0;
+
+    if (requireIndex && value < 0)
+        return 0;
+
+    if (index)
+        *index = value;
+
+    if (tail)
+        *tail = suffix + 1;
+
+    return 1;
+}
+
+int pathHasDevicePrefix(const char *path, const char *device)
+{
+    return pathParseDevicePrefix(path, device, NULL, NULL, 0);
 }
 
 void pathSetLaunchPath(const char *path)
@@ -67,33 +94,17 @@ int pathIsDevicePath(const char *path)
         return 0;
 
     for (i = 0; devices[i] != NULL; i++) {
-        if (path_starts_with_device(path, devices[i]))
+        if (pathHasDevicePrefix(path, devices[i]))
             return 1;
     }
 
     return 0;
 }
 
-int pathIsLegacyMassPath(const char *path)
+int pathIsUsbMassCompatPath(const char *path)
 {
-    const char *p;
-
-    if (!path || strncmp(path, "mass", 4))
-        return 0;
-
-    p = path + 4;
-
-    // wLE seems to use mass: instead of mass0:
-    if (*p == ':')
-        return 1;
-
-    if (*p < '0' || *p > '9')
-        return 0;
-
-    while (*p >= '0' && *p <= '9')
-        p++;
-
-    return *p == ':';
+    // wLE seems to use mass: instead of mass0:.. pathHasDevicePrefix() intentionally accepts both forms because the devN is optional
+    return pathHasDevicePrefix(path, "mass");
 }
 
 void pathNormaliseDir(char *dir, size_t dir_len)
@@ -114,20 +125,31 @@ void pathNormaliseDir(char *dir, size_t dir_len)
     }
 }
 
-static int path_get_dirname(const char *path, char *dir_out, size_t dir_len, int allowLegacyMass)
+static int path_get_dirname(const char *path, char *dir_out, size_t dir_len, int allowUsbMassCompat)
 {
     const char *slash;
+    const char *colon;
 
     if (!path || !path[0] || !dir_len)
         return 0;
 
-    if (!pathIsDevicePath(path) && (!allowLegacyMass || !pathIsLegacyMassPath(path)))
+    if (!pathIsDevicePath(path) && (!allowUsbMassCompat || !pathIsUsbMassCompatPath(path)))
         return 0;
 
     slash = strrchr(path, '/');
 
     if (!slash) {
-        copy_str(dir_out, path, dir_len);
+        colon = strchr(path, ':');
+
+        if (!colon)
+            return 0;
+
+        if ((size_t)(colon - path + 1) >= dir_len)
+            return 0;
+
+        memcpy(dir_out, path, colon - path + 1);
+        dir_out[colon - path + 1] = '\0';
+
         pathNormaliseDir(dir_out, dir_len);
         return 1;
     }
@@ -152,26 +174,14 @@ int pathGetBootDir(char *dir_out, size_t dir_len)
     if (path_get_dirname(launchPath, dir_out, dir_len, 1))
         return 1;
 
-    pwd[0] = '\0';
-
     if (getcwd(pwd, sizeof(pwd)) == NULL)
         return 0;
 
-    if (!pathIsDevicePath(pwd) && !pathIsLegacyMassPath(pwd))
+    if (!pathIsDevicePath(pwd) && !pathIsUsbMassCompatPath(pwd))
         return 0;
 
     copy_str(dir_out, pwd, dir_len);
     pathNormaliseDir(dir_out, dir_len);
-
-    return 1;
-}
-
-int pathResolveToTrue(char *out, size_t out_len, const char *path)
-{
-    if (!out || !out_len || !path)
-        return 0;
-
-    copy_str(out, path, out_len);
 
     return 1;
 }

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -67,11 +67,6 @@ int gPadMacroSettings;
 int gPadEmuSource;
 #endif
 
-int sbGetmcID(void)
-{
-    return mcID;
-}
-
 int sbGetFileSize(int fd)
 {
     int size = lseek(fd, 0, SEEK_END);
@@ -79,7 +74,12 @@ int sbGetFileSize(int fd)
     return size;
 }
 
-static int checkMC()
+int sbGetmcID(void)
+{
+    return mcID;
+}
+
+int sbCheckMC(void)
 {
     int mc0_is_ps2card, mc1_is_ps2card;
     int mc0_has_folder, mc1_has_folder;
@@ -140,62 +140,135 @@ static int checkMC()
     return mcID;
 }
 
-void sbCheckMCFolder(void)
+static int is_mc_config_path(const char *dir, int *slot)
 {
-    char path[32];
+    if (!dir || strncmp(dir, "mc", 2) != 0)
+        return 0;
+
+    if (dir[2] != '0' && dir[2] != '1')
+        return 0;
+
+    if (dir[3] != ':')
+        return 0;
+
+    if (slot)
+        *slot = dir[2] - '0';
+
+    return 1;
+}
+
+static int mc_slot_is_usable(int slot)
+{
+    char path[8];
+    DIR *root;
+
+    snprintf(path, sizeof(path), "mc%d:/", slot);
+
+    root = opendir(path);
+    if (root == NULL)
+        return 0;
+
+    closedir(root);
+    return 1;
+}
+
+static int normalise_mc_config_dir(char *out, int out_size, const char *dir)
+{
+    int len;
+
+    if (!out || out_size <= 0 || !dir)
+        return 0;
+
+    if (snprintf(out, out_size, "%s", dir) >= out_size)
+        return 0;
+
+    len = strlen(out);
+    if (len <= 0)
+        return 0;
+
+    if (out[len - 1] != '/') {
+        if (len + 1 >= out_size)
+            return 0;
+
+        out[len++] = '/';
+        out[len] = '\0';
+    }
+
+    return 1;
+}
+
+static int ensure_dir_exists(const char *dir)
+{
+    DIR *ldir;
+
+    ldir = opendir(dir);
+    if (ldir != NULL) {
+        closedir(ldir);
+        return 1;
+    }
+
+    if (mkdir(dir, 0777) == 0)
+        return 1;
+
+    ldir = opendir(dir);
+    if (ldir != NULL) {
+        closedir(ldir);
+        return 1;
+    }
+
+    return 0;
+}
+
+static void write_file_if_missing(const char *path, const void *data, int size)
+{
     int fd;
 
-    if (checkMC() < 0) {
+    fd = open(path, O_RDONLY);
+    if (fd >= 0) {
+        close(fd);
         return;
     }
 
-    snprintf(path, sizeof(path), "mc%d:%s/", mcID & 1, WOPL_CONFIG_NAME);
-    mkdir(path, 0777);
-
-    snprintf(path, sizeof(path), "mc%d:%s/list.icn", mcID & 1, WOPL_CONFIG_NAME);
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        fd = sbOpenFile(path, O_WRONLY | O_CREAT | O_TRUNC);
-        if (fd >= 0) {
-            write(fd, &icon_icn, size_icon_icn);
-            close(fd);
-        }
-    } else
-        close(fd);
-
-    snprintf(path, sizeof(path), "mc%d:%s/copy.icn", mcID & 1, WOPL_CONFIG_NAME);
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        fd = sbOpenFile(path, O_WRONLY | O_CREAT | O_TRUNC);
-        if (fd >= 0) {
-            write(fd, &icon_cpy_icn, size_icon_cpy_icn);
-            close(fd);
-        }
-    } else
-        close(fd);
-
-    snprintf(path, sizeof(path), "mc%d:%s/del.icn", mcID & 1, WOPL_CONFIG_NAME);
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        fd = sbOpenFile(path, O_WRONLY | O_CREAT | O_TRUNC);
-        if (fd >= 0) {
-            write(fd, &icon_del_icn, size_icon_del_icn);
-            close(fd);
-        }
-    } else
-        close(fd);
-
-    snprintf(path, sizeof(path), "mc%d:%s/icon.sys", mcID & 1, WOPL_CONFIG_NAME);
-    fd = open(path, O_RDONLY);
-    if (fd < 0) {
-        fd = sbOpenFile(path, O_WRONLY | O_CREAT | O_TRUNC);
-        if (fd >= 0) {
-            write(fd, &icon_sys, size_icon_sys);
-            close(fd);
-        }
-    } else {
+    fd = sbOpenFile((char *)path, O_WRONLY | O_CREAT | O_TRUNC);
+    if (fd >= 0) {
+        write(fd, data, size);
         close(fd);
     }
+}
+
+int sbEnsureMCConfigFolder(const char *dir)
+{
+    char folder[128];
+    char path[128];
+    int slot;
+
+    if (!is_mc_config_path(dir, &slot))
+        return 0;
+
+    if (!mc_slot_is_usable(slot))
+        return 0;
+
+    if (!normalise_mc_config_dir(folder, sizeof(folder), dir))
+        return 0;
+
+    if (!ensure_dir_exists(folder))
+        return 0;
+
+    mcID = '0' + slot;
+
+    snprintf(path, sizeof(path), "%slist.icn", folder);
+    write_file_if_missing(path, &icon_icn, size_icon_icn);
+
+    snprintf(path, sizeof(path), "%scopy.icn", folder);
+    write_file_if_missing(path, &icon_cpy_icn, size_icon_cpy_icn);
+
+    snprintf(path, sizeof(path), "%sdel.icn", folder);
+    write_file_if_missing(path, &icon_del_icn, size_icon_del_icn);
+
+    snprintf(path, sizeof(path), "%sicon.sys", folder);
+    write_file_if_missing(path, &icon_sys, size_icon_sys);
+
+    return 1;
 }
 
 static int checkFile(char *path, int mode)
@@ -207,7 +280,7 @@ static int checkFile(char *path, int mode)
         if (path[2] == 0x3F) {
 
             // Use default detected card
-            if (checkMC() >= 0)
+            if (sbCheckMC() >= 0)
                 path[2] = mcID;
             else
                 return 0;
@@ -232,7 +305,6 @@ static int checkFile(char *path, int mode)
     }
     return 1;
 }
-
 
 int sbIsSameSize(const char *prefix, int prevSize)
 {

--- a/src/supportbase.c
+++ b/src/supportbase.c
@@ -20,6 +20,7 @@
 #include "include/mmcesupport.h"
 #include "include/tar.h"
 #include "include/config_wopl.h"
+#include "include/pathsupport.h"
 
 #define NEWLIB_PORT_AWARE
 #include <fileXio_rpc.h> // fileXioMount("iso:", ***), fileXioUmount("iso:")
@@ -1625,36 +1626,6 @@ void sbCreateNeutrinoVMCPath(char *path, int length, const char *prefix, const c
         snprintf(path, length, "%sVMC/%s.bin", prefix, vmc);
 }
 
-static int sbParsePathDeviceIndex(const char *path, const char *prefix, int *device)
-{
-    const char *p;
-    int dev = 0;
-    int haveDigit = 0;
-    int prefixLen = strlen(prefix);
-
-    if (!path || strncmp(path, prefix, prefixLen))
-        return 0;
-
-    p = path + prefixLen;
-
-    while (*p >= '0' && *p <= '9') {
-        haveDigit = 1;
-        dev = dev * 10 + (*p - '0');
-        p++;
-    }
-
-    if (*p != ':')
-        return 0;
-
-    if (!haveDigit)
-        dev = 0;
-
-    if (device)
-        *device = dev;
-
-    return 1;
-}
-
 int sbGetPathModeAndDevice(const char *path, int *device)
 {
     const char *blkdevnameend;
@@ -1672,8 +1643,11 @@ int sbGetPathModeAndDevice(const char *path, int *device)
     if (!strncmp(path, "hdd0:", 5) || !strncmp(path, "pfs0:", 5))
         return HDD_MODE;
 
-    if (sbParsePathDeviceIndex(path, "mass", &dev)) {
-        if (dev < 0 || dev >= MAX_BDM_DEVICES)
+    if (pathParseDevicePrefix(path, "mass", &dev, NULL, 0)) {
+        if (dev < 0)
+            dev = 0;
+
+        if (dev >= MAX_BDM_DEVICES)
             return -1;
 
         if (device)
@@ -1682,7 +1656,10 @@ int sbGetPathModeAndDevice(const char *path, int *device)
         return BDM_MODE + dev;
     }
 
-    if (sbParsePathDeviceIndex(path, "mmce", &dev)) {
+    if (pathParseDevicePrefix(path, "mmce", &dev, NULL, 0)) {
+        if (dev < 0)
+            dev = 0;
+
         if (device)
             *device = dev;
 

--- a/src/system.c
+++ b/src/system.c
@@ -1162,19 +1162,22 @@ int sysCheckVMC(const char *prefix, const char *sep, char *name, int createSize,
 
 #include <elf-loader.h>
 
-static const char *getDeviceName(const char *driver)
+static const char *getDeviceName(const char *device)
 {
-    if (!strncmp(driver, "usb", 3))
-        return "usb";
-    else if (!strncmp(driver, "sdc", 3))
+    if (!device || !device[0])
+        return "unsupported";
+
+    if (!strncmp(device, "mx4sio", 6) || !strncmp(device, "sdc", 3))
         return "mx4sio";
-    else if (!strncmp(driver, "sd", 2))
+    else if (!strncmp(device, "ilink", 5) || !strcmp(device, "sd") || !strcmp(device, "sd:"))
         return "ilink";
-    else if (!strncmp(driver, "ata", 3))
+    else if (!strncmp(device, "usb", 3))
+        return "usb";
+    else if (!strncmp(device, "ata", 3))
         return "ata";
-    else if (!strncmp(driver, "apa", 3))
+    else if (!strncmp(device, "apa", 3))
         return "apa";
-    else if (!strncmp(driver, "mmce", 4))
+    else if (!strncmp(device, "mmce", 4))
         return "mmce";
     else
         return "unsupported";


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [ ] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
This pr changes cfg save/load logic to use current working device, ie if ELF is launched from ata0 it will save and load cfg files to/from ata0. Also moving from the old massN prefixes to true prefixes internally usb0 mx4sio1 mmce1 ata0 etc.. massN is still accepted as arvg0 but it is explicitly expected to be usb so don't use old loaders instead use: wLE r3z, PS2BBLE, osdmenu etc whatever also uses true prefix rather than the old massN.

With this we can also finally turn off usb module loading.

fixes #313 
should fix #210 but it would be nice to have confirmation on this one since merge auto closes the issue because I'm linking it